### PR TITLE
expand the set of configurations recognized as test paths

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Check.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Check.groovy
@@ -241,12 +241,20 @@ class Check extends DefaultTask {
      */
     def getAllDependencies(project) {
         return project.getConfigurations().findAll {
-            !config.skipTestGroups || (config.skipTestGroups && !it.getName().startsWith("test"))
+            !config.skipTestGroups || (config.skipTestGroups && !isTestConfiguration(it))
         }.collect {
             it.getResolvedConfiguration().getResolvedArtifacts().collect { ResolvedArtifact artifact ->
                 artifact.getFile()
             }
         }.flatten().unique();
+    }
+
+    /**
+     * Checks whether a configuration is considered to be a test configuration in order to skip it.
+     */
+    def isTestConfiguration(configuration) {
+        final String name = configuration.getName().toLowerCase();
+        return name.startsWith("test") || name.endsWith("testcompile") || name.endsWith("testruntime")
     }
 }
 


### PR DESCRIPTION
Hi, I recently started including the pugin in my builds and I'm finding a lot of false positives as multiple test paths are being included in the analysis.
Other than "test" we configure a bunch of other sourceSets for different types of tests (i.e. integrationTest, journeyTest, smokeTest, contractTest, androidTest...), for each of which gradle creates the -Runtime and -Compile configurations.
I believe that all of these configurations should be excluded from the analysis when the skipTestGroups is enabled.
This is a first attempt to expand on the exclusion issue based on my understanding of the industry consensus on naming alternative test sourceSets, any feedback on how to refine or expand it would be greatly appreciated.