### PR TITLE
adapt tests to various code changes

### DIFF
--- a/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginIntegSpec.groovy
+++ b/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginIntegSpec.groovy
@@ -10,14 +10,14 @@ class DependencyCheckGradlePluginIntegSpec extends IntegrationSpec {
     def "I can add the plugin to a build with no errors"() {
         setup:
         buildFile << '''
-            apply plugin: 'dependencyCheck'
+            apply plugin: 'org.owasp.dependencycheck'
         '''.stripIndent()
 
         when:
         ExecutionResult result = runTasksSuccessfully('tasks')
 
         then:
-        result.standardOutput.contains('dependencyCheck - Produce dependency security report.')
+        result.standardOutput.contains('dependencyCheck - Identifies and reports known vulnerabilities (CVEs) in project dependencies.')
     }
 
     def "I can override outputDir with extension"() {
@@ -29,6 +29,6 @@ class DependencyCheckGradlePluginIntegSpec extends IntegrationSpec {
         runTasksSuccessfully('dependencyCheck')
 
         then:
-        fileExists('build/dependencyCheckReport')
+        fileExists('build/dependency-reports/dependency-check-report.html')
     }
 }

--- a/src/integTest/resources/outputDir.gradle
+++ b/src/integTest/resources/outputDir.gradle
@@ -3,7 +3,7 @@
  * @author Sion Williams
  */
 apply plugin: 'java'
-apply plugin: 'dependencyCheck'
+apply plugin: 'org.owasp.dependencycheck'
 
 sourceCompatibility = 1.5
 version = '1.0'
@@ -17,5 +17,5 @@ dependencies {
 }
 
 dependencyCheck {
-    reportsDirName = "reports"
+    outputDirectory = "${project.buildDir}/dependency-reports"
 }

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
@@ -56,7 +56,7 @@ class DependencyCheckGradlePluginSpec extends PluginProjectSpec {
         project.dependencyCheck.cve.url20Modified == null
         project.dependencyCheck.cve.url12Base == null
         project.dependencyCheck.cve.url20Base == null
-        project.dependencyCheck.outputDirectory == 'build/reports'
+        project.dependencyCheck.outputDirectory == "${project.buildDir}/reports"
         project.dependencyCheck.quickQueryTimestamp == null
     }
 


### PR DESCRIPTION
This pull request adapts the unit test to #5.

The integration tests needed a bigger change as the plugin itself and the `outputDirectory` property had changed names. In addition the directory given as `outputDirectory` is created relative to the current working directory rather than the project's base directory so it was not where `fileExists` would expect it.