### PR TITLE
provide more control over scanned configurations

### DIFF
--- a/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
+++ b/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
@@ -1,0 +1,70 @@
+package org.owasp.dependencycheck.gradle
+
+import nebula.test.IntegrationSpec
+import nebula.test.functional.ExecutionResult
+
+class DependencyCheckConfigurationSelectionIntegSpec extends IntegrationSpec {
+
+    def "test dependencies are ignored by default"() {
+        setup:
+        writeHelloWorld('com.example')
+        copyResources('skipTestGroups.gradle', 'build.gradle')
+
+        when:
+        ExecutionResult result = runTasks('dependencyCheck')
+
+        then:
+        true == result.success
+    }
+
+    def "test dependencies are scanned if skipTestGroups flag is false"() {
+        setup:
+        writeHelloWorld('com.example')
+        copyResources('noSkipTestGroups.gradle', 'build.gradle')
+
+        when:
+        ExecutionResult result = runTasks('dependencyCheck')
+
+        then:
+        false == result.success
+        true == result.standardOutput.contains('CVE-2015-6420')
+    }
+
+    def "custom configurations are scanned by default"() {
+        setup:
+        writeHelloWorld('com.example')
+        copyResources('scanCustomConfiguration.gradle', 'build.gradle')
+
+        when:
+        ExecutionResult result = runTasks('dependencyCheck')
+
+        then:
+        false == result.success
+        true == result.standardOutput.contains('CVE-2015-6420')
+    }
+
+    def "custom configurations are skipped if blacklisted"() {
+        setup:
+        writeHelloWorld('com.example')
+        copyResources('blacklistCustomConfiguration.gradle', 'build.gradle')
+
+        when:
+        ExecutionResult result = runTasks('dependencyCheck')
+
+        then:
+        true == result.success
+    }
+
+    def "custom configurations are skipped when only scanning whitelisted configurations"() {
+        setup:
+        writeHelloWorld('com.example')
+        copyResources('skipCustomConfigurationViaWhitelist.gradle', 'build.gradle')
+
+        when:
+        ExecutionResult result = runTasks('dependencyCheck')
+
+        then:
+        true == result.success
+    }
+
+}

--- a/src/integTest/resources/blacklistCustomConfiguration.gradle
+++ b/src/integTest/resources/blacklistCustomConfiguration.gradle
@@ -1,0 +1,22 @@
+apply plugin: 'java'
+apply plugin: 'org.owasp.dependencycheck'
+
+sourceCompatibility = 1.5
+version = '1.0'
+
+repositories {
+    mavenCentral()
+}
+
+configurations {
+    foo
+}
+
+dependencies {
+    foo group: 'commons-collections', name: 'commons-collections', version: '3.2'
+}
+
+dependencyCheck {
+    failBuildOnCVSS = 0
+    skipConfigurations = ['foo']
+}

--- a/src/integTest/resources/noSkipTestGroups.gradle
+++ b/src/integTest/resources/noSkipTestGroups.gradle
@@ -1,0 +1,18 @@
+apply plugin: 'java'
+apply plugin: 'org.owasp.dependencycheck'
+
+sourceCompatibility = 1.5
+version = '1.0'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testCompile group: 'commons-collections', name: 'commons-collections', version: '3.2'
+}
+
+dependencyCheck {
+    failBuildOnCVSS = 0
+    skipTestGroups = false
+}

--- a/src/integTest/resources/scanCustomConfiguration.gradle
+++ b/src/integTest/resources/scanCustomConfiguration.gradle
@@ -1,0 +1,21 @@
+apply plugin: 'java'
+apply plugin: 'org.owasp.dependencycheck'
+
+sourceCompatibility = 1.5
+version = '1.0'
+
+repositories {
+    mavenCentral()
+}
+
+configurations {
+    foo
+}
+
+dependencies {
+    foo group: 'commons-collections', name: 'commons-collections', version: '3.2'
+}
+
+dependencyCheck {
+    failBuildOnCVSS = 0
+}

--- a/src/integTest/resources/skipCustomConfigurationViaWhitelist.gradle
+++ b/src/integTest/resources/skipCustomConfigurationViaWhitelist.gradle
@@ -1,0 +1,22 @@
+apply plugin: 'java'
+apply plugin: 'org.owasp.dependencycheck'
+
+sourceCompatibility = 1.5
+version = '1.0'
+
+repositories {
+    mavenCentral()
+}
+
+configurations {
+    foo
+}
+
+dependencies {
+    foo group: 'commons-collections', name: 'commons-collections', version: '3.2'
+}
+
+dependencyCheck {
+    failBuildOnCVSS = 0
+    scanConfigurations = ['runtime']
+}

--- a/src/integTest/resources/skipTestGroups.gradle
+++ b/src/integTest/resources/skipTestGroups.gradle
@@ -1,0 +1,17 @@
+apply plugin: 'java'
+apply plugin: 'org.owasp.dependencycheck'
+
+sourceCompatibility = 1.5
+version = '1.0'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testCompile group: 'commons-collections', name: 'commons-collections', version: '3.2'
+}
+
+dependencyCheck {
+    failBuildOnCVSS = 0
+}

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/CheckExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/CheckExtension.groovy
@@ -73,4 +73,18 @@ class CheckExtension extends UpdateExtension {
      * Displays a summary of the findings. Defaults to true.
      */
     Boolean showSummary = true
+
+    /**
+     * Names of the configurations to scan.
+     *
+     * This is mutually exclusive with the skipConfigurations property.
+     */
+    List<String> scanConfigurations = []
+
+    /**
+     * Names of the configurations to skip when scanning.
+     *
+     * This is mutually exclusive with the scanConfigurations property.
+     */
+    List<String> skipConfigurations = []
 }

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
@@ -58,6 +58,8 @@ class DependencyCheckGradlePluginSpec extends PluginProjectSpec {
         project.dependencyCheck.cve.url20Base == null
         project.dependencyCheck.outputDirectory == 'build/reports'
         project.dependencyCheck.quickQueryTimestamp == null
+        project.dependencyCheck.scanConfigurations == []
+        project.dependencyCheck.skipConfigurations == []
     }
 
     def 'tasks use correct values when extension is used'() {
@@ -79,6 +81,9 @@ class DependencyCheckGradlePluginSpec extends PluginProjectSpec {
 
             outputDirectory = 'outputDirectory'
             quickQueryTimestamp = false
+
+            scanConfigurations = ['a']
+            skipConfigurations = ['b']
         }
 
         then:
@@ -92,5 +97,19 @@ class DependencyCheckGradlePluginSpec extends PluginProjectSpec {
         project.dependencyCheck.cve.url20Base == 'cveUrl20Base'
         project.dependencyCheck.outputDirectory == 'outputDirectory'
         project.dependencyCheck.quickQueryTimestamp == false
+        project.dependencyCheck.scanConfigurations == ['a']
+        project.dependencyCheck.skipConfigurations == ['b']
+    }
+
+    def 'scanConfigurations and skipConfigurations are mutually exclusive'() {
+        when:
+        project.dependencyCheck {
+            scanConfigurations = ['a']
+            skipConfigurations = ['b']
+        }
+        task = project.tasks.findByName('dependencyCheck').check()
+
+        then:
+        thrown(IllegalArgumentException)
     }
 }


### PR DESCRIPTION
This commit adds two new properties to the `dependencyCheck` task:

`skipConfigurations` accepts a list of configuration names. The
dependencies of the named configurations are not analyzed. This does not
prevent the dependencies from being checked if other configurations
contain them as well - for example if other configurations extend the
named configurations.

`scanConfigurations` accepts a list of configuration names. Only the
dependencies of the named configurations will be analyzed.

`skipConfigurations` and `scanConfigurations` are mutually exclusive.

closes #6