### PR TITLE
Added skipBuildGroups flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ language: groovy
 before_install:
   - chmod +x gradlew
 
-script:
-  - ./gradlew check
+after_success:
+  - ./gradlew integTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: groovy
 
-gradle check
+before_install:
+  - chmod +x gradlew
+
+script:
+  - ./gradlew check

--- a/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
+++ b/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
@@ -67,4 +67,29 @@ class DependencyCheckConfigurationSelectionIntegSpec extends IntegrationSpec {
         true == result.success
     }
 
+    def "build dependencies are ignored by default"() {
+        setup:
+        writeHelloWorld('com.example')
+        copyResources('skipBuildGroups.gradle', 'build.gradle')
+
+        when:
+        ExecutionResult result = runTasks('dependencyCheck')
+
+        then:
+        true == result.success
+    }
+
+    def "build dependencies are scanned if skipBuildGroups flag is false"() {
+        setup:
+        writeHelloWorld('com.example')
+        copyResources('noSkipBuildGroups.gradle', 'build.gradle')
+
+        when:
+        ExecutionResult result = runTasks('dependencyCheck')
+
+        then:
+        false == result.success
+        true == result.standardOutput.contains('CVE-2015-6420')
+    }
+
 }

--- a/src/integTest/resources/noSkipBuildGroups.gradle
+++ b/src/integTest/resources/noSkipBuildGroups.gradle
@@ -1,0 +1,20 @@
+apply plugin: 'java'
+apply plugin: 'org.owasp.dependencycheck'
+
+sourceCompatibility = 1.5
+version = '1.0'
+
+repositories {
+    mavenCentral()
+}
+
+buildscript {
+  dependencies {
+      classpath group: 'commons-collections', name: 'commons-collections', version: '3.2'
+  }
+}
+
+dependencyCheck {
+    failBuildOnCVSS = 0
+    skipBuildGroups = false
+}

--- a/src/integTest/resources/skipBuildGroups.gradle
+++ b/src/integTest/resources/skipBuildGroups.gradle
@@ -1,0 +1,19 @@
+apply plugin: 'java'
+apply plugin: 'org.owasp.dependencycheck'
+
+sourceCompatibility = 1.5
+version = '1.0'
+
+repositories {
+    mavenCentral()
+}
+
+buildscript {
+  dependencies {
+      classpath group: 'commons-collections', name: 'commons-collections', version: '3.2'
+  }
+}
+
+dependencyCheck {
+    failBuildOnCVSS = 0
+}

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Check.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Check.groovy
@@ -249,7 +249,7 @@ class Check extends DefaultTask {
      */
     def getAllDependencies(project) {
         return project.getConfigurations().findAll {
-            shouldBeScanned(it) && !(shouldBeSkipped(it) || shouldBeSkippedAsTest(it))
+            shouldBeScanned(it) && !(shouldBeSkipped(it) || shouldBeSkippedAsTest(it) || shouldBeSkippedAsBuild(it))
         }.collect {
             it.getResolvedConfiguration().getResolvedArtifacts().collect { ResolvedArtifact artifact ->
                 artifact.getFile()
@@ -289,5 +289,21 @@ class Check extends DefaultTask {
         final String name = configuration.getName().toLowerCase();
         return name.startsWith("test") || name.endsWith("testcompile") || name.endsWith("testruntime")
     }
-}
 
+    /**
+     * Checks whether the given configuration should be skipped
+     * because it is a build configuration and skipBuildGroups is true.
+     */
+    def shouldBeSkippedAsBuild(configuration) {
+        config.skipBuildGroups && isBuildConfiguration(configuration)
+    }
+
+    /**
+     * Checks whether a configuration is considered to be a build configuration in order to skip it.
+     */
+    def isBuildConfiguration(configuration) {
+        final String name = configuration.getName().toLowerCase();
+        return name.startsWith("classpath")
+    }
+
+}


### PR DESCRIPTION
- implements https://github.com/jeremylong/DependencyCheck/issues/519
- fixes Travis-CI configuration
- adds execution of ```gradle integTest``` after successful build

Unfortunately I couldn't get ```gradle integTest``` to run: It fails for all existing and my new tests with some obscure ```org.gradle.api.plugins.UnknownPluginException```.