### PR TITLE
Test configuration detection is broken

### DIFF
--- a/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
+++ b/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
@@ -28,6 +28,9 @@ class DependencyCheckConfigurationSelectionIntegSpec extends IntegrationSpec {
         then:
         false == result.success
         true == result.standardOutput.contains('CVE-2015-6420')
+        true == result.standardOutput.contains('CVE-2014-0114')
+        true == result.standardOutput.contains('CVE-2016-3092')
+        true == result.standardOutput.contains('CVE-2015-5262')
     }
 
     def "custom configurations are scanned by default"() {

--- a/src/integTest/resources/noSkipTestGroups.gradle
+++ b/src/integTest/resources/noSkipTestGroups.gradle
@@ -8,8 +8,20 @@ repositories {
     mavenCentral()
 }
 
+sourceSets {
+    intTest
+}
+
+configurations {
+    intTestCompile.extendsFrom(testCompile)
+    intTestRuntime.extendsFrom(testRuntime)
+}
+
 dependencies {
     testCompile group: 'commons-collections', name: 'commons-collections', version: '3.2'
+    intTestCompileOnly group: 'commons-beanutils', name: 'commons-beanutils-core', version: '1.8.3'
+    intTestCompile group: 'commons-fileupload', name: 'commons-fileupload', version: '1.3.1'
+    intTestRuntime group: 'commons-httpclient', name: 'commons-httpclient', version: '3.1'
 }
 
 dependencyCheck {

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/CheckExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/CheckExtension.groovy
@@ -54,7 +54,8 @@ class CheckExtension extends UpdateExtension {
     //The following properties are not used via the settings object, instead
     // they are directly used by the check task.
     /**
-     * When set to true dependency groups that start with 'test' will not be included in the analysis.
+     * When set to true configurations that are considered a test configuration will not be included in the analysis.
+     * A configuration is considered a test configuration if and only if extends (transitively) from testCompile.
      * The default value is true.
      */
     Boolean skipTestGroups = true

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/CheckExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/CheckExtension.groovy
@@ -55,7 +55,13 @@ class CheckExtension extends UpdateExtension {
     // they are directly used by the check task.
     /**
      * When set to true configurations that are considered a test configuration will not be included in the analysis.
-     * A configuration is considered a test configuration if and only if extends (transitively) from testCompile.
+     * A configuration is considered a test configuration if and only if any of the following conditions holds:
+     * <ul>
+     *     <li>the name of the configuration or any of its parent configurations equals 'testCompile'</li>
+     *     <li>the name of the configuration or any of its parent configurations equals 'androidTestCompile'</li>
+     *     <li>the configuration name starts with 'test'</li>
+     *     <li>the configuration name starts with 'androidTest'</li>
+     * </ul>
      * The default value is true.
      */
     Boolean skipTestGroups = true

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Check.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Check.groovy
@@ -306,14 +306,20 @@ class Check extends DefaultTask {
 
     /**
      * Checks whether a configuration is considered to be a test configuration in order to skip it.
-     * This boils down to check whether a configuration extends (transitively) from {@code testCompile}.
+     * A configuration is considered a test configuration if and only if any of the following conditions holds:
+     * <ul>
+     *     <li>the name of the configuration or any of its parent configurations equals 'testCompile'</li>
+     *     <li>the name of the configuration or any of its parent configurations equals 'androidTestCompile'</li>
+     *     <li>the configuration name starts with 'test'</li>
+     *     <li>the configuration name starts with 'androidTest'</li>
+     * </ul>
      */
     def isTestConfiguration(configuration) {
-        def isTestConfiguration = false
+        def isTestConfiguration = configuration.name.startsWith("test") || configuration.name.startsWith("androidTest")
         configuration.hierarchy.each {
-            isTestConfiguration |= it.name.equals("testCompile")
+            isTestConfiguration |= (it.name == "testCompile" || it.name == "androidTestCompile")
         }
-        logger.debug("'${configuration.name}' is a test configuration: ${isTestConfiguration}")
+        logger.info("'${configuration.name}' is considered a test configuration: ${isTestConfiguration}")
         isTestConfiguration
     }
 }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Check.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Check.groovy
@@ -304,6 +304,15 @@ class Check extends DefaultTask {
         config.skipTestGroups && isTestConfiguration(configuration)
     }
 
+    def isTestConfiguration(configuration) {
+        def isTestConfiguration = isTestConfigurationCheck(configuration)
+
+        def hierarchy = configuration.hierarchy.collect({ it.name }).join(" --> ")
+        logger.info("'{}' is considered a test configuration: {}", hierarchy, isTestConfiguration)
+
+        isTestConfiguration
+    }
+
     /**
      * Checks whether a configuration is considered to be a test configuration in order to skip it.
      * A configuration is considered a test configuration if and only if any of the following conditions holds:
@@ -314,12 +323,11 @@ class Check extends DefaultTask {
      *     <li>the configuration name starts with 'androidTest'</li>
      * </ul>
      */
-    def isTestConfiguration(configuration) {
+    def static isTestConfigurationCheck(configuration) {
         def isTestConfiguration = configuration.name.startsWith("test") || configuration.name.startsWith("androidTest")
         configuration.hierarchy.each {
             isTestConfiguration |= (it.name == "testCompile" || it.name == "androidTestCompile")
         }
-        logger.info("'${configuration.name}' is considered a test configuration: ${isTestConfiguration}")
         isTestConfiguration
     }
 }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Check.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Check.groovy
@@ -306,10 +306,14 @@ class Check extends DefaultTask {
 
     /**
      * Checks whether a configuration is considered to be a test configuration in order to skip it.
+     * This boils down to check whether a configuration extends (transitively) from {@code testCompile}.
      */
     def isTestConfiguration(configuration) {
-        final String name = configuration.getName().toLowerCase();
-        return name.startsWith("test") || name.endsWith("testcompile") || name.endsWith("testruntime")
+        def isTestConfiguration = false
+        configuration.hierarchy.each {
+            isTestConfiguration |= it.name.equals("testCompile")
+        }
+        logger.debug("'${configuration.name}' is a test configuration: ${isTestConfiguration}")
+        isTestConfiguration
     }
 }
-

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
@@ -60,6 +60,7 @@ class DependencyCheckGradlePluginSpec extends PluginProjectSpec {
         project.dependencyCheck.quickQueryTimestamp == null
         project.dependencyCheck.scanConfigurations == []
         project.dependencyCheck.skipConfigurations == []
+        project.dependencyCheck.skipTestGroups == true
     }
 
     def 'tasks use correct values when extension is used'() {
@@ -84,6 +85,7 @@ class DependencyCheckGradlePluginSpec extends PluginProjectSpec {
 
             scanConfigurations = ['a']
             skipConfigurations = ['b']
+            skipTestGroups = false
         }
 
         then:
@@ -99,6 +101,7 @@ class DependencyCheckGradlePluginSpec extends PluginProjectSpec {
         project.dependencyCheck.quickQueryTimestamp == false
         project.dependencyCheck.scanConfigurations == ['a']
         project.dependencyCheck.skipConfigurations == ['b']
+        project.dependencyCheck.skipTestGroups == false
     }
 
     def 'scanConfigurations and skipConfigurations are mutually exclusive'() {

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/tasks/CheckSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/tasks/CheckSpec.groovy
@@ -7,36 +7,9 @@ import spock.lang.Unroll
 class CheckSpec extends Specification {
 
     @Unroll
-    def "Configuration '#configurationName' (extends no other configuration) is considered a test configuration"() {
+    def "IS considered a test Configuration: '#configurationHierarchy'"() {
         given:
-        def configuration = stubConfiguration(configurationName)
-        configuration.hierarchy >> []
-
-        expect:
-        Check.isTestConfigurationCheck(configuration)
-
-        where:
-        configurationName << ["test", "testApk", "androidTest", "androidTestApk"]
-    }
-
-    @Unroll
-    def "Configuration '#configurationName' (extends no other configuration) is NOT considered a test configuration"() {
-        given:
-        def configuration = stubConfiguration(configurationName)
-        configuration.hierarchy >> []
-
-        expect:
-        !Check.isTestConfigurationCheck(configuration)
-
-        where:
-        configurationName << ["teStart", "androIdTest"]
-    }
-
-    @Unroll
-    def "Configuration '#configurationHierarchy' is considered a test configuration"() {
-        given:
-        def configurationName = configurationHierarchy.remove(0)
-        def configuration = stubConfiguration(configurationName)
+        def configuration = stubConfiguration(configurationHierarchy[0])
         configuration.hierarchy >> configurationHierarchy.collect { stubConfiguration(it) }
 
         expect:
@@ -44,16 +17,19 @@ class CheckSpec extends Specification {
 
         where:
         configurationHierarchy << [
+                ["test"],
+                ["testApk"],
+                ["androidTest"],
+                ["androidTestApk"],
                 ["teStart", "testRuntime", "testCompile"],
                 ["teStart", "androIdTest", "androidTestCompile"]
         ]
     }
 
     @Unroll
-    def "Configuration '#configurationHierarchy' is NOT considered a test configuration"() {
+    def "Is NOT considered a test configuration: '#configurationHierarchy'"() {
         given:
-        def configurationName = configurationHierarchy.remove(0)
-        def configuration = stubConfiguration(configurationName)
+        def configuration = stubConfiguration(configurationHierarchy[0])
         configuration.hierarchy >> configurationHierarchy.collect { stubConfiguration(it) }
 
         expect:
@@ -61,6 +37,8 @@ class CheckSpec extends Specification {
 
         where:
         configurationHierarchy << [
+                ["teStart"],
+                ["androIdTest"],
                 ["teStart", "test"],
                 ["teStart", "androidTest"],
                 ["teStart", "runtime", "compile"],

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/tasks/CheckSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/tasks/CheckSpec.groovy
@@ -1,0 +1,79 @@
+package org.owasp.dependencycheck.gradle.tasks
+
+import org.gradle.api.artifacts.Configuration
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class CheckSpec extends Specification {
+
+    @Unroll
+    def "Configuration '#configurationName' (extends no other configuration) is considered a test configuration"() {
+        given:
+        def configuration = stubConfiguration(configurationName)
+        configuration.hierarchy >> []
+
+        expect:
+        Check.isTestConfigurationCheck(configuration)
+
+        where:
+        configurationName << ["test", "testApk", "androidTest", "androidTestApk"]
+    }
+
+    @Unroll
+    def "Configuration '#configurationName' (extends no other configuration) is NOT considered a test configuration"() {
+        given:
+        def configuration = stubConfiguration(configurationName)
+        configuration.hierarchy >> []
+
+        expect:
+        !Check.isTestConfigurationCheck(configuration)
+
+        where:
+        configurationName << ["teStart", "androIdTest"]
+    }
+
+    @Unroll
+    def "Configuration '#configurationHierarchy' is considered a test configuration"() {
+        given:
+        def configurationName = configurationHierarchy.remove(0)
+        def configuration = stubConfiguration(configurationName)
+        configuration.hierarchy >> configurationHierarchy.collect { stubConfiguration(it) }
+
+        expect:
+        Check.isTestConfigurationCheck(configuration)
+
+        where:
+        configurationHierarchy << [
+                ["teStart", "testRuntime", "testCompile"],
+                ["teStart", "androIdTest", "androidTestCompile"]
+        ]
+    }
+
+    @Unroll
+    def "Configuration '#configurationHierarchy' is NOT considered a test configuration"() {
+        given:
+        def configurationName = configurationHierarchy.remove(0)
+        def configuration = stubConfiguration(configurationName)
+        configuration.hierarchy >> configurationHierarchy.collect { stubConfiguration(it) }
+
+        expect:
+        !Check.isTestConfigurationCheck(configuration)
+
+        where:
+        configurationHierarchy << [
+                ["teStart", "test"],
+                ["teStart", "androidTest"],
+                ["teStart", "runtime", "compile"],
+                ["teStart", "testRuntime", "testCompileFoo"],
+                ["teStart", "androIdTest", "androidTestCompileFoo"]
+
+        ]
+    }
+
+
+    def stubConfiguration(String configurationName) {
+        def configuration = Stub(Configuration)
+        configuration.name >> configurationName
+        configuration
+    }
+}


### PR DESCRIPTION
Let skipTestGroups check the inheritance hierarchy of a configuration to decide whether it is to be considered a test configuration