### PR TITLE
Fix syntax error

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Check.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Check.groovy
@@ -79,7 +79,7 @@ class Check extends DefaultTask {
                 engine.analyzeDependencies();
             } catch (ExceptionCollection ex) {
                 if (config.failOnError && ex.isFatal()) {
-                    throw new GradleException(ex);
+                    throw new GradleException("Analysis failed.", ex);
                 }
                 exCol = ex
             }


### PR DESCRIPTION
GradleException does not have a CTOR that takes only an exception/a throwable:
* [Javadoc (current)](https://docs.gradle.org/current/javadoc/org/gradle/api/GradleException.html)
* [Javadoc (v2.0)](https://docs.gradle.org/2.0/javadoc/org/gradle/api/GradleException.html)
* [Javadoc (v1.0)](https://docs.gradle.org/1.0/javadoc/org/gradle/api/GradleException.html)