### PR TITLE
Differentiating extension name from task name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
  */
 
 group = 'org.owasp'
-version = '1.4.5'
+version = '1.4.5.1'
 
 buildscript {
     repositories {

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/DependencyCheck.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/DependencyCheck.groovy
@@ -27,7 +27,7 @@ import org.owasp.dependencycheck.gradle.tasks.Purge
 import org.owasp.dependencycheck.gradle.tasks.Update
 
 class DependencyCheck implements Plugin<Project> {
-    private static final String CHECK_TASK = 'dependencyCheck'
+    private static final String CHECK_TASK = 'dependencyCheckAnalyzer'
     private static final String UPDATE_TASK = 'dependencyCheckUpdate'
     private static final String PURGE_TASK = 'dependencyCheckPurge'
 
@@ -35,15 +35,16 @@ class DependencyCheck implements Plugin<Project> {
     private static final String PROXY_EXTENSION_NAME = "proxy"
     private static final String CVE_EXTENSION_NAME = "cve"
     private static final String DATA_EXTENSION_NAME = "data"
+    private static final String CHECK_EXTENSION_NAME = "dependencyCheck"
     private static final String ANALYZERS_EXTENSION_NAME = "analyzers"
 
-    def void apply(Project project) {
+    void apply(Project project) {
         initializeConfigurations(project)
         registerTasks(project)
     }
 
-    def void initializeConfigurations(Project project) {
-        def ext = project.extensions.create(CHECK_TASK, CheckExtension, project)
+    void initializeConfigurations(Project project) {
+        def ext = project.extensions.create(CHECK_EXTENSION_NAME, CheckExtension, project)
         ext.extensions.create(PROXY_EXTENSION_NAME, ProxyExtension)
         ext.extensions.create(CVE_EXTENSION_NAME, CveExtension)
         ext.extensions.create(DATA_EXTENSION_NAME, DataExtension)
@@ -58,15 +59,9 @@ class DependencyCheck implements Plugin<Project> {
         purge.extensions.create(DATA_EXTENSION_NAME, PurgeDataExtension)
     }
 
-    def void registerTasks(Project project) {
+    void registerTasks(Project project) {
         project.task(PURGE_TASK, type: Purge)
         project.task(UPDATE_TASK, type: Update)
         project.task(CHECK_TASK, type: Check)
-
-        // this add the dependencyCheck task to the check; however it turns out users don't want this as they would
-        // rather configure this themselves.
-        //project.plugins.withType(JavaPlugin) {
-        //    project.tasks.check.dependsOn project.tasks.getByName(CHECK_TASK)
-        //}
     }
 }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/CveExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/CveExtension.groovy
@@ -18,7 +18,7 @@
 
 package org.owasp.dependencycheck.gradle.extension
 
-public class CveExtension {
+class CveExtension {
     /**
      * URL for the modified CVE 1.2:
      *    https://nvd.nist.gov/download/nvdcve-Modified.xml.gz

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Check.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Check.groovy
@@ -58,7 +58,7 @@ class Check extends DefaultTask {
      * all of the projects dependencies.
      */
     @TaskAction
-    def check() {
+    check() {
         verifySettings()
         initializeSettings()
         def engine = null
@@ -77,10 +77,10 @@ class Check extends DefaultTask {
             ExceptionCollection exCol = null
             logger.lifecycle("Checking for updates and analyzing vulnerabilities for dependencies")
             try {
-                engine.analyzeDependencies();
+                engine.analyzeDependencies()
             } catch (ExceptionCollection ex) {
                 if (config.failOnError && ex.isFatal()) {
-                    throw new GradleException("Analysis failed.", ex);
+                    throw new GradleException("Analysis failed.", ex)
                 }
                 exCol = ex
             }
@@ -114,7 +114,7 @@ class Check extends DefaultTask {
 
     def verifySettings() {
         if (config.scanConfigurations && config.skipConfigurations) {
-            throw new IllegalArgumentException("you can only specify one of scanConfigurations or skipConfigurations");
+            throw new IllegalArgumentException("you can only specify one of scanConfigurations or skipConfigurations")
         }
     }
 
@@ -148,9 +148,9 @@ class Check extends DefaultTask {
 
         if (config.cveValidForHours != null) {
             if (config.cveValidForHours >= 0) {
-                Settings.setInt(CVE_CHECK_VALID_FOR_HOURS, config.cveValidForHours);
+                Settings.setInt(CVE_CHECK_VALID_FOR_HOURS, config.cveValidForHours)
             } else {
-                throw new InvalidUserDataException("Invalid setting: `validForHours` must be 0 or greater");
+                throw new InvalidUserDataException("Invalid setting: `validForHours` must be 0 or greater")
             }
         }
         Settings.setBooleanIfNotNull(ANALYZER_JAR_ENABLED, config.analyzers.jarEnabled)
@@ -186,7 +186,7 @@ class Check extends DefaultTask {
      */
     def cleanup(engine) {
         Settings.cleanup(true)
-        engine.cleanup();
+        engine.cleanup()
     }
 
     /**
@@ -265,22 +265,22 @@ class Check extends DefaultTask {
             dependency.getVulnerabilities()
         }.flatten()
 
-        final StringBuilder ids = new StringBuilder();
+        final StringBuilder ids = new StringBuilder()
 
         vulnerabilities.each {
             if (it.getCvssScore() >= config.failBuildOnCVSS) {
                 if (ids.length() == 0) {
-                    ids.append(it.getName());
+                    ids.append(it.getName())
                 } else {
-                    ids.append(", ").append(it.getName());
+                    ids.append(", ").append(it.getName())
                 }
             }
         }
         if (ids.length() > 0) {
             final String msg = String.format("%n%nDependency-Check Failure:%n"
                     + "One or more dependencies were identified with vulnerabilities that have a CVSS score greater then '%.1f': %s%n"
-                    + "See the dependency-check report for more details.%n%n", config.failBuildOnCVSS, ids.toString());
-            throw new GradleException(msg);
+                    + "See the dependency-check report for more details.%n%n", config.failBuildOnCVSS, ids.toString())
+            throw new GradleException(msg)
         }
 
     }
@@ -330,7 +330,7 @@ class Check extends DefaultTask {
      *     <li>the configuration name starts with 'androidTest'</li>
      * </ul>
      */
-    def static isTestConfigurationCheck(configuration) {
+    static isTestConfigurationCheck(configuration) {
         def isTestConfiguration = configuration.name.startsWith("test") || configuration.name.startsWith("androidTest")
         configuration.hierarchy.each {
             isTestConfiguration |= (it.name == "testCompile" || it.name == "androidTestCompile")

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Purge.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Purge.groovy
@@ -44,7 +44,7 @@ class Purge extends DefaultTask {
      * Purges the local cache of the NVD data.
      */
     @TaskAction
-    def purge() {
+    purge() {
         initializeSettings()
         def db = new File(Settings.getDataDirectory(), "dc.h2.db")
         if (db.exists()) {

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Update.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Update.groovy
@@ -65,7 +65,7 @@ class Update extends DefaultTask {
      * Executes the update task.
      */
     @TaskAction
-    def update() {
+    update() {
         initializeSettings()
         def engine = null
         try {
@@ -119,9 +119,9 @@ class Update extends DefaultTask {
 
         if (config.cveValidForHours != null) {
             if (config.cveValidForHours >= 0) {
-                Settings.setInt(CVE_CHECK_VALID_FOR_HOURS, config.cveValidForHours);
+                Settings.setInt(CVE_CHECK_VALID_FOR_HOURS, config.cveValidForHours)
             } else {
-                throw new InvalidUserDataException("Invalid setting: `validForHours` must be 0 or greater");
+                throw new InvalidUserDataException("Invalid setting: `validForHours` must be 0 or greater")
             }
         }
     }
@@ -130,6 +130,6 @@ class Update extends DefaultTask {
      */
     def cleanup(engine) {
         Settings.cleanup(true)
-        engine.cleanup();
+        engine.cleanup()
     }
 }

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
@@ -38,12 +38,12 @@ class DependencyCheckGradlePluginSpec extends PluginProjectSpec {
     }
 
     def "apply creates dependencyCheck task"() {
-        expect: project.tasks.findByName( 'dependencyCheck' )
+        expect: project.tasks.findByName( 'dependencyCheckAnalyzer' )
     }
 
     def 'dependencyCheck task has correct default values'() {
         setup:
-        Task task = project.tasks.findByName( 'dependencyCheck' )
+        Task task = project.tasks.findByName( 'dependencyCheckAnalyzer' )
 
         expect:
         task.group == 'OWASP dependency-check'
@@ -110,7 +110,7 @@ class DependencyCheckGradlePluginSpec extends PluginProjectSpec {
             scanConfigurations = ['a']
             skipConfigurations = ['b']
         }
-        task = project.tasks.findByName('dependencyCheck').check()
+        task = project.tasks.findByName('dependencyCheckAnalyzer').check()
 
         then:
         thrown(IllegalArgumentException)

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/tasks/CheckSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/tasks/CheckSpec.groovy
@@ -7,7 +7,7 @@ import spock.lang.Unroll
 class CheckSpec extends Specification {
 
     @Unroll
-    def "IS considered a test Configuration: '#configurationHierarchy'"() {
+    "IS considered a test Configuration: '#configurationHierarchy'"() {
         given:
         def configuration = stubConfiguration(configurationHierarchy[0])
         configuration.hierarchy >> configurationHierarchy.collect { stubConfiguration(it) }
@@ -27,7 +27,7 @@ class CheckSpec extends Specification {
     }
 
     @Unroll
-    def "Is NOT considered a test configuration: '#configurationHierarchy'"() {
+    "Is NOT considered a test configuration: '#configurationHierarchy'"() {
         given:
         def configuration = stubConfiguration(configurationHierarchy[0])
         configuration.hierarchy >> configurationHierarchy.collect { stubConfiguration(it) }


### PR DESCRIPTION
Defining the CHECK_TASK and CHECK_EXTENSION_NAME as the same value causes headaches when trying to invoke functionality typically available on Gradle Tasks e.g. doFirst {} or doLast {}.
```
// inside build.gradle...

dependencyCheck {
    format = 'ALL'
}

// blows up with v.1.4.5
//dependencyCheck.doLast {
//    println 'in the doLast!!!!!!'
//}

// ugly workaround
tasks['dependencyCheck'].doLast {
    println 'in the doLast!!!!!!'
}
```
Users of the plugin cannot gain direct access to the task because Gradle doesn't know if they are trying to reference the extension or the task (since both are the same name).  It seems when there's a conflict Gradle defaults to the extension.

The least invasive fix is provided in this pull request by creating a different name for the task while leaving the extension as the original value.  This allows for backwards compatibility for anyone who currently has extension properties defined  on 'dependencyCheck' while allowing people moving forward to add to the task 'dependencyCheckAnalyzer' if they have further work they want to add around the task.
```
// inside build.gradle...

dependencyCheck {
    format = 'ALL'
}

// works in v.1.4.5.1
dependencyCheckAnalyzer.doLast {
    println 'in the doLast!!!!!!'
}
```

In the future it might be worth considering refactoring the Plugin to do most the work in the Tasks so contributors of the plugin can make use of the provided annotations (e.g. @OutputDirectory) and end-users can configure the plugin similar to other plugins.