### PR TITLE
remove / unify duplicate config extensions for purge and update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
  */
 
 group = 'org.owasp'
-version = '1.4.5.1'
+version = '1.4.5.2-SNAPSHOT'
 
 buildscript {
     repositories {

--- a/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
+++ b/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
@@ -13,7 +13,7 @@ class DependencyCheckConfigurationSelectionIntegSpec extends IntegrationSpec {
         copyResources('skipTestGroups.gradle', 'build.gradle')
 
         when:
-        ExecutionResult result = runTasks('dependencyCheckAnalyze')
+        ExecutionResult result = runTasks(DependencyCheck.CHECK_TASK)
 
         then:
         true == result.success
@@ -25,7 +25,7 @@ class DependencyCheckConfigurationSelectionIntegSpec extends IntegrationSpec {
         copyResources('noSkipTestGroups.gradle', 'build.gradle')
 
         when:
-        ExecutionResult result = runTasks('dependencyCheckAnalyze')
+        ExecutionResult result = runTasks(DependencyCheck.CHECK_TASK)
 
         then:
         false == result.success
@@ -41,7 +41,7 @@ class DependencyCheckConfigurationSelectionIntegSpec extends IntegrationSpec {
         copyResources('scanCustomConfiguration.gradle', 'build.gradle')
 
         when:
-        ExecutionResult result = runTasks('dependencyCheckAnalyze')
+        ExecutionResult result = runTasks(DependencyCheck.CHECK_TASK)
 
         then:
         false == result.success
@@ -54,7 +54,7 @@ class DependencyCheckConfigurationSelectionIntegSpec extends IntegrationSpec {
         copyResources('blacklistCustomConfiguration.gradle', 'build.gradle')
 
         when:
-        ExecutionResult result = runTasks('dependencyCheckAnalyze')
+        ExecutionResult result = runTasks(DependencyCheck.CHECK_TASK)
 
         then:
         true == result.success
@@ -66,7 +66,7 @@ class DependencyCheckConfigurationSelectionIntegSpec extends IntegrationSpec {
         copyResources('skipCustomConfigurationViaWhitelist.gradle', 'build.gradle')
 
         when:
-        ExecutionResult result = runTasks('dependencyCheckAnalyze')
+        ExecutionResult result = runTasks(DependencyCheck.CHECK_TASK)
 
         then:
         true == result.success

--- a/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginIntegSpec.groovy
+++ b/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginIntegSpec.groovy
@@ -17,7 +17,12 @@ class DependencyCheckGradlePluginIntegSpec extends IntegrationSpec {
         ExecutionResult result = runTasksSuccessfully('tasks')
 
         then:
-        result.standardOutput.contains('dependencyCheckAnalyze - Identifies and reports known vulnerabilities (CVEs) in project dependencies.')
+        result.standardOutput.contains(
+                String.format(
+                        '%s - Identifies and reports known vulnerabilities (CVEs) in project dependencies.',
+                        DependencyCheck.CHECK_TASK
+                )
+        )
     }
 
     def "I can override outputDir with extension"() {
@@ -26,7 +31,7 @@ class DependencyCheckGradlePluginIntegSpec extends IntegrationSpec {
         copyResources('outputDir.gradle', 'build.gradle')
 
         when:
-        runTasksSuccessfully('dependencyCheckAnalyze')
+        runTasksSuccessfully(DependencyCheck.CHECK_TASK)
 
         then:
         fileExists('build/dependency-reports/dependency-check-report.html')

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/DependencyCheck.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/DependencyCheck.groovy
@@ -20,23 +20,22 @@ package org.owasp.dependencycheck.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.plugins.JavaPlugin
 import org.owasp.dependencycheck.gradle.extension.*
 import org.owasp.dependencycheck.gradle.tasks.Check
 import org.owasp.dependencycheck.gradle.tasks.Purge
 import org.owasp.dependencycheck.gradle.tasks.Update
 
 class DependencyCheck implements Plugin<Project> {
-    private static final String CHECK_TASK = 'dependencyCheckAnalyze'
-    private static final String UPDATE_TASK = 'dependencyCheckUpdate'
-    private static final String PURGE_TASK = 'dependencyCheckPurge'
+    static final String CHECK_TASK = 'dependencyCheckAnalyze'
+    static final String UPDATE_TASK = 'dependencyCheckUpdate'
+    static final String PURGE_TASK = 'dependencyCheckPurge'
 
     /* configuration extensions */
-    private static final String PROXY_EXTENSION_NAME = "proxy"
-    private static final String CVE_EXTENSION_NAME = "cve"
-    private static final String DATA_EXTENSION_NAME = "data"
-    private static final String CHECK_EXTENSION_NAME = "dependencyCheck"
-    private static final String ANALYZERS_EXTENSION_NAME = "analyzers"
+    private static final String CHECK_EXTENSION_NAME = 'dependencyCheck'
+    private static final String PROXY_EXTENSION_NAME = 'proxy'
+    private static final String CVE_EXTENSION_NAME = 'cve'
+    private static final String DATA_EXTENSION_NAME = 'data'
+    private static final String ANALYZERS_EXTENSION_NAME = 'analyzers'
 
     void apply(Project project) {
         initializeConfigurations(project)
@@ -49,19 +48,11 @@ class DependencyCheck implements Plugin<Project> {
         ext.extensions.create(CVE_EXTENSION_NAME, CveExtension)
         ext.extensions.create(DATA_EXTENSION_NAME, DataExtension)
         ext.extensions.create(ANALYZERS_EXTENSION_NAME, AnalyzerExtension)
-
-        def update = project.extensions.create(UPDATE_TASK, UpdateExtension)
-        update.extensions.create(CVE_EXTENSION_NAME, CveExtension)
-        update.extensions.create(DATA_EXTENSION_NAME, DataExtension)
-        update.extensions.create(PROXY_EXTENSION_NAME, ProxyExtension)
-
-        def purge = project.extensions.create(PURGE_TASK, PurgeExtension)
-        purge.extensions.create(DATA_EXTENSION_NAME, PurgeDataExtension)
     }
 
     void registerTasks(Project project) {
-        project.task(PURGE_TASK, type: Purge)
-        project.task(UPDATE_TASK, type: Update)
         project.task(CHECK_TASK, type: Check)
+        project.task(UPDATE_TASK, type: Update)
+        project.task(PURGE_TASK, type: Purge)
     }
 }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Purge.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Purge.groovy
@@ -30,7 +30,7 @@ import static org.owasp.dependencycheck.utils.Settings.KEYS.DATA_DIRECTORY
  */
 class Purge extends DefaultTask {
 
-    def config = project.dependencyCheckPurge
+    def config = project.dependencyCheck
 
     /**
      * Initializes the purge task.

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Update.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Update.groovy
@@ -51,7 +51,7 @@ import static org.owasp.dependencycheck.utils.Settings.KEYS.DB_PASSWORD
  */
 class Update extends DefaultTask {
 
-    def config = project.dependencyCheckUpdate
+    def config = project.dependencyCheck
 
     /**
      * Initializes the update task.

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
@@ -38,12 +38,12 @@ class DependencyCheckGradlePluginSpec extends PluginProjectSpec {
     }
 
     def "apply creates dependencyCheck task"() {
-        expect: project.tasks.findByName( 'dependencyCheckAnalyze' )
+        expect: project.tasks.findByName( DependencyCheck.CHECK_TASK  )
     }
 
     def 'dependencyCheck task has correct default values'() {
         setup:
-        Task task = project.tasks.findByName( 'dependencyCheckAnalyze' )
+        Task task = project.tasks.findByName( DependencyCheck.CHECK_TASK  )
 
         expect:
         task.group == 'OWASP dependency-check'
@@ -110,7 +110,7 @@ class DependencyCheckGradlePluginSpec extends PluginProjectSpec {
             scanConfigurations = ['a']
             skipConfigurations = ['b']
         }
-        task = project.tasks.findByName('dependencyCheckAnalyze').check()
+        task = project.tasks.findByName(DependencyCheck.CHECK_TASK).check()
 
         then:
         thrown(IllegalArgumentException)


### PR DESCRIPTION
removed / unified duplicate config extensions for purge and update that
messed up the configuration and needed to redefine
```groovy
dependencyCheckPurge {
  data = dependencyCheck.data
}
```
and
```groovy
dependencyCheckUpdate {
  data = dependencyCheck.data
  cve = dependencyCheck.cve
  proxy = dependencyCheck.proxy
}
```