### PR TITLE
Add aggregate task per issue #13

### DIFF
--- a/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
+++ b/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
@@ -105,10 +105,12 @@ class DependencyCheckConfigurationSelectionIntegSpec extends Specification {
         given:
         def resource = new File(getClass().getClassLoader().getResource('aggregateParent.gradle').toURI())
         buildFile << resource.text
-        def app = testProjectDir.newFolder('app').createNewFile('build.gradle')
+        def appDir = testProjectDir.newFolder('app')
+        def app = appDir.createNewFile('build.gradle')
         def appBuild = new File(getClass().getClassLoader().getResource('aggregateApp.gradle').toURI())
         app << appBuild.text
-        def core = testProjectDir.newFolder('core').createNewFile('build.gradle')
+        def coreDir = testProjectDir.newFolder('core')
+        def core = coreDir.createNewFile('build.gradle')
         def coreBuild = new File(getClass().getClassLoader().getResource('aggregateCore.gradle').toURI())
         core << coreBuild.text
 

--- a/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
+++ b/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
@@ -105,6 +105,11 @@ class DependencyCheckConfigurationSelectionIntegSpec extends Specification {
         given:
         def resource = new File(getClass().getClassLoader().getResource('aggregateParent.gradle').toURI())
         buildFile << resource.text
+
+        File settingsFile = testProjectDir.newFile('settings.gradle')
+        def settingsResource = new File(getClass().getClassLoader().getResource('aggregateSettings.gradle').toURI())
+        settingsFile << settingsResource.text
+
         File appDir = testProjectDir.newFolder('app')
         File app = new File(appDir,'build.gradle')
         def appBuild = new File(getClass().getClassLoader().getResource('aggregateApp.gradle').toURI())

--- a/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
+++ b/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
@@ -105,11 +105,11 @@ class DependencyCheckConfigurationSelectionIntegSpec extends Specification {
         given:
         def resource = new File(getClass().getClassLoader().getResource('aggregateParent.gradle').toURI())
         buildFile << resource.text
-        def appDir = testProjectDir.newFolder('app')
+        File appDir = testProjectDir.newFolder('app')
         def app = appDir.createNewFile('build.gradle')
         def appBuild = new File(getClass().getClassLoader().getResource('aggregateApp.gradle').toURI())
         app << appBuild.text
-        def coreDir = testProjectDir.newFolder('core')
+        File coreDir = testProjectDir.newFolder('core')
         def core = coreDir.createNewFile('build.gradle')
         def coreBuild = new File(getClass().getClassLoader().getResource('aggregateCore.gradle').toURI())
         core << coreBuild.text

--- a/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
+++ b/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
@@ -23,13 +23,13 @@ class DependencyCheckConfigurationSelectionIntegSpec extends Specification {
         when:
         def result = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments(DependencyCheckPlugin.CHECK_TASK)
+                .withArguments(DependencyCheckPlugin.ANALYZE_TASK)
                 .withPluginClasspath()
                 .withDebug(true)
                 .build()
 
         then:
-        result.task(":$DependencyCheckPlugin.CHECK_TASK").outcome == SUCCESS
+        result.task(":$DependencyCheckPlugin.ANALYZE_TASK").outcome == SUCCESS
     }
 
     def "test dependencies are scanned if skipTestGroups flag is false"() {
@@ -40,12 +40,12 @@ class DependencyCheckConfigurationSelectionIntegSpec extends Specification {
         when:
         def result = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments(DependencyCheckPlugin.CHECK_TASK)
+                .withArguments(DependencyCheckPlugin.ANALYZE_TASK)
                 .withPluginClasspath()
                 .buildAndFail()
 
         then:
-        result.task(":$DependencyCheckPlugin.CHECK_TASK").outcome == FAILED
+        result.task(":$DependencyCheckPlugin.ANALYZE_TASK").outcome == FAILED
         result.output.contains('CVE-2015-6420')
         result.output.contains('CVE-2014-0114')
         result.output.contains('CVE-2016-3092')
@@ -60,12 +60,12 @@ class DependencyCheckConfigurationSelectionIntegSpec extends Specification {
         when:
         def result = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments(DependencyCheckPlugin.CHECK_TASK)
+                .withArguments(DependencyCheckPlugin.ANALYZE_TASK)
                 .withPluginClasspath()
                 .buildAndFail()
 
         then:
-        result.task(":$DependencyCheckPlugin.CHECK_TASK").outcome == FAILED
+        result.task(":$DependencyCheckPlugin.ANALYZE_TASK").outcome == FAILED
         result.output.contains('CVE-2015-6420')
     }
 
@@ -77,12 +77,12 @@ class DependencyCheckConfigurationSelectionIntegSpec extends Specification {
         when:
         def result = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments(DependencyCheckPlugin.CHECK_TASK)
+                .withArguments(DependencyCheckPlugin.ANALYZE_TASK)
                 .withPluginClasspath()
                 .build()
 
         then:
-        result.task(":$DependencyCheckPlugin.CHECK_TASK").outcome == SUCCESS
+        result.task(":$DependencyCheckPlugin.ANALYZE_TASK").outcome == SUCCESS
     }
 
     def "custom configurations are skipped when only scanning whitelisted configurations"() {
@@ -93,11 +93,35 @@ class DependencyCheckConfigurationSelectionIntegSpec extends Specification {
         when:
         def result = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments(DependencyCheckPlugin.CHECK_TASK)
+                .withArguments(DependencyCheckPlugin.ANALYZE_TASK)
                 .withPluginClasspath()
                 .build()
 
         then:
-        result.task(":$DependencyCheckPlugin.CHECK_TASK").outcome == SUCCESS
+        result.task(":$DependencyCheckPlugin.ANALYZE_TASK").outcome == SUCCESS
+    }
+
+    def "aggregate task aggregates"() {
+        given:
+        def resource = new File(getClass().getClassLoader().getResource('aggregateParent.gradle').toURI())
+        buildFile << resource.text
+        def app = testProjectDir.newFolder('app').createNewFile('build.gradle')
+        def appBuild = new File(getClass().getClassLoader().getResource('aggregateApp.gradle').toURI())
+        app << appBuild.text
+        def core = testProjectDir.newFolder('core').createNewFile('build.gradle')
+        def coreBuild = new File(getClass().getClassLoader().getResource('aggregateCore.gradle').toURI())
+        core << coreBuild.text
+
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments(DependencyCheckPlugin.AGGREGATE_TASK)
+                .withPluginClasspath()
+                .build()
+
+        then:
+        result.task(":$DependencyCheckPlugin.AGGREGATE_TASK").outcome == SUCCESS
+        result.output.contains('CVE-2016-7051') //jackson cve from core
+        result.output.contains('CVE-2015-6420') //commons cve from app
     }
 }

--- a/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
+++ b/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
@@ -106,11 +106,11 @@ class DependencyCheckConfigurationSelectionIntegSpec extends Specification {
         def resource = new File(getClass().getClassLoader().getResource('aggregateParent.gradle').toURI())
         buildFile << resource.text
         File appDir = testProjectDir.newFolder('app')
-        def app = appDir.createNewFile('build.gradle')
+        File app = new File(appDir,'build.gradle')
         def appBuild = new File(getClass().getClassLoader().getResource('aggregateApp.gradle').toURI())
         app << appBuild.text
         File coreDir = testProjectDir.newFolder('core')
-        def core = coreDir.createNewFile('build.gradle')
+        File core = new File(coreDir, 'build.gradle')
         def coreBuild = new File(getClass().getClassLoader().getResource('aggregateCore.gradle').toURI())
         core << coreBuild.text
 

--- a/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPluginIntegSpec.groovy
+++ b/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPluginIntegSpec.groovy
@@ -32,7 +32,7 @@ class DependencyCheckPluginIntegSpec extends Specification {
             .build()
 
         then:
-        result.output.contains("$DependencyCheckPlugin.CHECK_TASK")
+        result.output.contains("$DependencyCheckPlugin.ANALYZE_TASK")
     }
 
     def "custom configurations are skipped when only scanning whitelisted configurations"() {
@@ -59,11 +59,11 @@ class DependencyCheckPluginIntegSpec extends Specification {
         when:
         def result = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments(DependencyCheckPlugin.CHECK_TASK)
+                .withArguments(DependencyCheckPlugin.ANALYZE_TASK)
                 .withPluginClasspath()
                 .build()
 
         then:
-        result.task(":$DependencyCheckPlugin.CHECK_TASK").outcome == SUCCESS
+        result.task(":$DependencyCheckPlugin.ANALYZE_TASK").outcome == SUCCESS
     }
 }

--- a/src/integTest/resources/aggregateApp.gradle
+++ b/src/integTest/resources/aggregateApp.gradle
@@ -1,0 +1,6 @@
+apply plugin: 'application'
+
+dependencies {
+    compile 'log4j:log4j:1.2.17'
+    compile group: 'commons-collections', name: 'commons-collections', version: '3.2'
+}

--- a/src/integTest/resources/aggregateCore.gradle
+++ b/src/integTest/resources/aggregateCore.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    testCompile 'junit:junit:4.11'
+    compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.7.0'
+}

--- a/src/integTest/resources/aggregateParent.gradle
+++ b/src/integTest/resources/aggregateParent.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id 'org.owasp.dependencycheck'
+    id 'java'
+}
+
+dependencyCheck {
+    failOnError=true
+    format="ALL"
+}
+
+subprojects {
+    apply plugin: 'java'
+
+    repositories {
+        mavenCentral()
+    }
+}

--- a/src/integTest/resources/aggregateSettings.gradle
+++ b/src/integTest/resources/aggregateSettings.gradle
@@ -1,0 +1,4 @@
+rootProject.name = 'multi-project-build'
+include 'app'
+include 'core'
+

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPlugin.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPlugin.groovy
@@ -26,11 +26,13 @@ import org.owasp.dependencycheck.gradle.extension.CveExtension
 import org.owasp.dependencycheck.gradle.extension.DataExtension
 import org.owasp.dependencycheck.gradle.extension.ProxyExtension
 import org.owasp.dependencycheck.gradle.tasks.Update
-import org.owasp.dependencycheck.gradle.tasks.Check
+import org.owasp.dependencycheck.gradle.tasks.Analyze
+import org.owasp.dependencycheck.gradle.tasks.Aggregate
 import org.owasp.dependencycheck.gradle.tasks.Purge
 
 class DependencyCheckPlugin implements Plugin<Project> {
-    public static final String CHECK_TASK = 'dependencyCheckAnalyze'
+    public static final String ANALYZE_TASK = 'dependencyCheckAnalyze'
+    public static final String AGGREGATE_TASK = 'dependencyCheckAggregate'
     public static final String UPDATE_TASK = 'dependencyCheckUpdate'
     public static final String PURGE_TASK = 'dependencyCheckPurge'
 
@@ -57,6 +59,7 @@ class DependencyCheckPlugin implements Plugin<Project> {
     void registerTasks(Project project) {
         project.task(PURGE_TASK, type: Purge)
         project.task(UPDATE_TASK, type: Update)
-        project.task(CHECK_TASK, type: Check)
+        project.task(ANALYZE_TASK, type: Analyze)
+        project.task(AGGREGATE_TASK, type: Aggregate)
     }
 }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Aggregate.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Aggregate.groovy
@@ -1,0 +1,66 @@
+/*
+ * This file is part of dependency-check-gradle.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2015 Wei Ma. All Rights Reserved.
+ */
+
+package org.owasp.dependencycheck.gradle.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.owasp.dependencycheck.Engine
+import org.owasp.dependencycheck.data.nvdcve.DatabaseException
+import org.owasp.dependencycheck.dependency.Confidence
+import org.owasp.dependencycheck.dependency.Dependency
+import org.owasp.dependencycheck.dependency.Identifier
+import org.owasp.dependencycheck.dependency.Vulnerability
+import org.owasp.dependencycheck.exception.ExceptionCollection
+import org.owasp.dependencycheck.exception.ReportException
+import org.owasp.dependencycheck.utils.Settings
+
+import static org.owasp.dependencycheck.utils.Settings.KEYS.*
+
+/**
+ * Checks the projects dependencies for known vulnerabilities.
+ */
+class Aggregate extends AbstractAnalyze {
+
+    Aggregate() {
+        group = 'OWASP dependency-check'
+        description = 'Identifies and reports known vulnerabilities (CVEs) in multi-project dependencies.'
+    }
+
+    /**
+     * Loads the projects dependencies into the dependency-check analysis engine.
+     */
+    def scanDependencies(engine) {
+        logger.lifecycle("Verifying dependencies for project ${currentProjectName}")
+        project.rootProject.allprojects.collectMany {
+            it.configurations.findAll {
+                shouldBeScanned(it) && !(shouldBeSkipped(it) || shouldBeSkippedAsTest(it)) && canBeResolved(it)
+            }.each { Configuration configuration ->
+                configuration.getResolvedConfiguration().getResolvedArtifacts().collect { ResolvedArtifact artifact ->
+                    def deps = engine.scan(artifact.getFile())
+                    addInfoToDependencies(deps, artifact, "$it.name:$configuration.name")
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Analyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Analyze.groovy
@@ -1,0 +1,65 @@
+/*
+ * This file is part of dependency-check-gradle.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2015 Wei Ma. All Rights Reserved.
+ */
+
+package org.owasp.dependencycheck.gradle.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.api.artifacts.ResolvedDependency
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.Internal
+import org.owasp.dependencycheck.Engine
+import org.owasp.dependencycheck.data.nvdcve.DatabaseException
+import org.owasp.dependencycheck.dependency.Confidence
+import org.owasp.dependencycheck.exception.ExceptionCollection
+import org.owasp.dependencycheck.exception.ReportException
+import org.owasp.dependencycheck.dependency.Dependency
+import org.owasp.dependencycheck.dependency.Identifier
+import org.owasp.dependencycheck.dependency.Vulnerability
+import org.owasp.dependencycheck.utils.Settings
+import static org.owasp.dependencycheck.utils.Settings.KEYS.*
+
+/**
+ * Checks the projects dependencies for known vulnerabilities.
+ */
+class Analyze extends AbstractAnalyze {
+
+    Analyze() {
+        group = 'OWASP dependency-check'
+        description = 'Identifies and reports known vulnerabilities (CVEs) in project dependencies.'
+    }
+
+    /**
+     * Loads the projects dependencies into the dependency-check analysis engine.
+     */
+    def scanDependencies(engine) {
+        logger.lifecycle("Verifying dependencies for project ${currentProjectName}")
+        project.getConfigurations().findAll {
+            shouldBeScanned(it) && !(shouldBeSkipped(it) || shouldBeSkippedAsTest(it)) && canBeResolved(it)
+        }.each { Configuration configuration ->
+            configuration.getResolvedConfiguration().getResolvedArtifacts().collect { ResolvedArtifact artifact ->
+                def deps = engine.scan(artifact.getFile())
+                addInfoToDependencies(deps, artifact, configuration.name)
+            }
+        }
+    }
+
+}

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
@@ -39,7 +39,12 @@ class DependencyCheckGradlePluginSpec extends Specification {
 
     def "dependencyCheckAnalyze task exists"() {
         expect:
-        project.tasks.findByName(DependencyCheckPlugin.CHECK_TASK)
+        project.tasks.findByName(DependencyCheckPlugin.ANALYZE_TASK)
+    }
+
+    def "dependencyCheckAggregate task exists"() {
+        expect:
+        project.tasks.findByName(DependencyCheckPlugin.AGGREGATE_TASK)
     }
 
     def "dependencyCheckPurge task exists"() {
@@ -54,7 +59,7 @@ class DependencyCheckGradlePluginSpec extends Specification {
 
     def 'dependencyCheck task has correct default values'() {
         setup:
-        Task task = project.tasks.findByName(DependencyCheckPlugin.CHECK_TASK)
+        Task task = project.tasks.findByName(DependencyCheckPlugin.ANALYZE_TASK)
 
         expect:
         task.group == 'OWASP dependency-check'
@@ -128,7 +133,7 @@ class DependencyCheckGradlePluginSpec extends Specification {
             scanConfigurations = ['a']
             skipConfigurations = ['b']
         }
-        task = project.tasks.findByName(DependencyCheckPlugin.CHECK_TASK).check()
+        task = project.tasks.findByName(DependencyCheckPlugin.ANALYZE_TASK).analyze()
 
         then:
         thrown(IllegalArgumentException)


### PR DESCRIPTION
This PR adds an aggregation task: `dependencyCheckAggregate`.

Note, this does not aggregate dependency check reports generated by `dependencyCheckAnalyze` (i.e. this is not a "merge" task). Rather this task will cycle threw all sub-projects from the root and run dependency check on them and write the results to a single report.