### PR TITLE
ignore java-classes-directory types from scanned dependencies

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Analyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Analyze.groovy
@@ -55,7 +55,9 @@ class Analyze extends AbstractAnalyze {
         project.getConfigurations().findAll {
             shouldBeScanned(it) && !(shouldBeSkipped(it) || shouldBeSkippedAsTest(it)) && canBeResolved(it)
         }.each { Configuration configuration ->
-            configuration.getResolvedConfiguration().getResolvedArtifacts().collect { ResolvedArtifact artifact ->
+            configuration.getResolvedConfiguration().getResolvedArtifacts().findAll{ResolvedArtifact artifact ->
+				! "java-classes-directory".equals(artifact.getType())
+			}.collect { ResolvedArtifact artifact ->
                 def deps = engine.scan(artifact.getFile())
                 //TODO determine why deps could be null in some cases.
                 addInfoToDependencies(deps, artifact, configuration.name)


### PR DESCRIPTION
gradle multi-module build: optimization by ignoring java-classes-directories
please validate this fix as I'm new to gradle plugin development