### PR TITLE
Add Shutdown Hook

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
  */
 
 group = 'org.owasp'
-version = '3.0.2'
+version = '3.1.0-SNAPSHOT'
  
 buildscript {
     repositories {
@@ -64,8 +64,8 @@ dependencies {
         localGroovy(),
         gradleApi(),
         'commons-collections:commons-collections:3.2.2',
-        'org.owasp:dependency-check-core:3.0.2',
-        'org.owasp:dependency-check-utils:3.0.2'
+        'org.owasp:dependency-check-core:3.1.0-SNAPSHOT',
+        'org.owasp:dependency-check-utils:3.1.0-SNAPSHOT'
     )
 
     testCompile gradleTestKit()

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -48,6 +48,8 @@ abstract class AbstractAnalyze extends DefaultTask {
     def config = project.dependencyCheck
     @Internal
     def settings
+    @Internal
+    def PROPERTIES_FILE = "task.properties"
 
     /**
      * Calls dependency-check-core's analysis engine to scan
@@ -134,6 +136,25 @@ abstract class AbstractAnalyze extends DefaultTask {
      */
     def initializeSettings() {
         settings = new Settings()
+
+
+        InputStream taskProperties = null;
+        try {
+            taskProperties = this.getClass().getClassLoader().getResourceAsStream(PROPERTIES_FILE);
+            settings.mergeProperties(taskProperties);
+        } catch (IOException ex) {
+            logger.warn("Unable to load the dependency-check gradle task.properties file.");
+            logger.debug("", ex);
+        } finally {
+            if (taskProperties != null) {
+                try {
+                    taskProperties.close();
+                } catch (IOException ex) {
+                    logger.debug("", ex);
+                }
+            }
+        }
+
 
         settings.setBooleanIfNotNull(AUTO_UPDATE, config.autoUpdate)
 

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/utils/H2DBCleanupHook.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/utils/H2DBCleanupHook.groovy
@@ -1,0 +1,51 @@
+/*
+ * This file is part of dependency-check-gradle.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2017 Jeremy Long. All Rights Reserved.
+ */
+
+package org.owasp.dependencycheck.gradle.utils
+
+import org.gradle.process.internal.shutdown.ShutdownHookActionRegister
+import org.owasp.dependencycheck.utils.H2DBLock
+
+class H2DBCleanupHook extends org.owasp.dependencycheck.utils.H2DBCleanupHook {
+
+    /**
+     * A reference to the lock file.
+     */
+    def lock
+
+    @Override
+    void add(H2DBLock h2DBLock) {
+        super.add(h2DBLock)
+        lock = h2DBLock
+        ShutdownHookActionRegister.addAction(this)
+    }
+
+    @Override
+    void remove() {
+        super.remove();
+        ShutdownHookActionRegister.removeAction(this);
+    }
+
+    @Override
+    void run() {
+        if (lock != null) {
+            lock.release()
+            lock = null
+        }
+    }
+}

--- a/src/main/resources/task.properties
+++ b/src/main/resources/task.properties
@@ -1,0 +1,4 @@
+# the path to the data directory
+data.directory=[JAR]/../../dependency-check-data/3.0
+# the class name of the H2 database shutdown hook
+data.h2.shutdownhook=org.owasp.dependencycheck.gradle.utils.H2DBCleanupHook


### PR DESCRIPTION
Fixes issue with the custom h2 db lock file being left when the build is killed early. See https://github.com/jeremylong/DependencyCheck/pull/1030#issuecomment-352187395

Note - this also updates the data directory for gradle so that it should now consistently be located in: `~/.gradle/dependency-check-data/`.