### PR TITLE
Update dependency-check-core to 3.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
         localGroovy(),
         gradleApi(),
         'commons-collections:commons-collections:3.2.2',
-        'org.owasp:dependency-check-core:3.1.1',
+        'org.owasp:dependency-check-core:3.1.2',
         'org.owasp:dependency-check-utils:3.1.1'
     )
 


### PR DESCRIPTION
Release v3.1.2 contains the fix for https://github.com/jeremylong/DependencyCheck/issues/1171