### PR TITLE
Fix Null Dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
  */
 
 group = 'org.owasp'
-version = '3.3.0'
+version = '3.3.0-SNAPSHOT'
  
 buildscript {
     repositories {
@@ -64,8 +64,8 @@ dependencies {
         localGroovy(),
         gradleApi(),
         'commons-collections:commons-collections:3.2.2',
-        'org.owasp:dependency-check-core:3.3.0',
-        'org.owasp:dependency-check-utils:3.3.0'
+        'org.owasp:dependency-check-core:3.3.0-SNAPSHOT',
+        'org.owasp:dependency-check-utils:3.3.0-SNAPSHOT'
     )
 
     testCompile gradleTestKit()

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
  */
 
 group = 'org.owasp'
-version = '3.2.2-SNAPSHOT'
+version = '3.3.0'
  
 buildscript {
     repositories {
@@ -64,8 +64,8 @@ dependencies {
         localGroovy(),
         gradleApi(),
         'commons-collections:commons-collections:3.2.2',
-        'org.owasp:dependency-check-core:3.2.2-SNAPSHOT',
-        'org.owasp:dependency-check-utils:3.2.2-SNAPSHOT'
+        'org.owasp:dependency-check-core:3.3.0',
+        'org.owasp:dependency-check-utils:3.3.0'
     )
 
     testCompile gradleTestKit()

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -427,4 +427,44 @@ abstract class AbstractAnalyze extends DefaultTask {
         def id = artifact.moduleVersion.id
         new MavenArtifact(id.group, id.name, id.version)
     }
+
+    /**
+     * Adds a virtual dependency to the engine. This is used when an artifact is scanned that is not
+     * supported by dependency-check (different dependency type for possibly new language).
+     * @param engine a reference to the engine
+     * @param projectName the project name
+     * @param configurationName the configuration name
+     * @param groupid the group id
+     * @param name the name or artifact id
+     * @param version the version number
+     * @param displayName the display name
+     */
+    protected void addVirtualDependency(Engine engine, String projectName, String configurationName,
+                                        String groupid, String name, String version, String displayName) {
+
+        logger.info("Adding virtual dependency for ${displayName}")
+
+        Dependency virtualDependency = new Dependency(new File(project.buildDir, "../build.gradle"), true)
+
+        virtualDependency.setSha1sum(Checksum.getSHA1Checksum("${groupid}:${name}:${version}"))
+        virtualDependency.setSha256sum(Checksum.getSHA256Checksum("${groupid}:${name}:${version}"))
+        virtualDependency.setMd5sum(Checksum.getMD5Checksum("${groupid}:${name}:${version}"))
+        virtualDependency.addEvidence(EvidenceType.VENDOR, "build.gradle", "group", groupid, Confidence.HIGHEST)
+        virtualDependency.addEvidence(EvidenceType.VENDOR, "build.gradle", "name", name, Confidence.MEDIUM)
+        virtualDependency.addEvidence(EvidenceType.VENDOR, "build.gradle", "displayName", displayName, Confidence.MEDIUM)
+        virtualDependency.addEvidence(EvidenceType.PRODUCT, "build.gradle", "group", groupid, Confidence.MEDIUM)
+        virtualDependency.addEvidence(EvidenceType.PRODUCT, "build.gradle", "name", name, Confidence.HIGHEST)
+        virtualDependency.addEvidence(EvidenceType.PRODUCT, "build.gradle", "displayName", displayName, Confidence.HIGH)
+        virtualDependency.addEvidence(EvidenceType.VERSION, "build.gradle", "version", version, Confidence.HIGHEST)
+        virtualDependency.setName(name)
+        virtualDependency.setVersion(version)
+        virtualDependency.setDisplayFileName(displayName ? displayName : "${groupid}:${name}:${version}")
+        virtualDependency.setPackagePath("${groupid}:${name}:${version}")
+        virtualDependency.addProjectReference("${projectName}:${configurationName}")
+        virtualDependency.setEcosystem("gradle")
+        virtualDependency.addIdentifier("maven", "${groupid}:${name}:${version}",
+                null, Confidence.HIGHEST)
+
+        engine.addDependency(virtualDependency);
+    }
 }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -442,7 +442,8 @@ abstract class AbstractAnalyze extends DefaultTask {
     protected void addVirtualDependency(Engine engine, String projectName, String configurationName,
                                         String groupid, String name, String version, String displayName) {
 
-        logger.info("Adding virtual dependency for ${displayName}")
+        def display = displayName ?: "${groupid}:${name}:${version}"
+        logger.info("Adding virtual dependency for ${display}")
 
         Dependency virtualDependency = new Dependency(new File(project.buildDir, "../build.gradle"), true)
 
@@ -451,14 +452,14 @@ abstract class AbstractAnalyze extends DefaultTask {
         virtualDependency.setMd5sum(Checksum.getMD5Checksum("${groupid}:${name}:${version}"))
         virtualDependency.addEvidence(EvidenceType.VENDOR, "build.gradle", "group", groupid, Confidence.HIGHEST)
         virtualDependency.addEvidence(EvidenceType.VENDOR, "build.gradle", "name", name, Confidence.MEDIUM)
-        virtualDependency.addEvidence(EvidenceType.VENDOR, "build.gradle", "displayName", displayName, Confidence.MEDIUM)
+        virtualDependency.addEvidence(EvidenceType.VENDOR, "build.gradle", "displayName", display, Confidence.MEDIUM)
         virtualDependency.addEvidence(EvidenceType.PRODUCT, "build.gradle", "group", groupid, Confidence.MEDIUM)
         virtualDependency.addEvidence(EvidenceType.PRODUCT, "build.gradle", "name", name, Confidence.HIGHEST)
-        virtualDependency.addEvidence(EvidenceType.PRODUCT, "build.gradle", "displayName", displayName, Confidence.HIGH)
+        virtualDependency.addEvidence(EvidenceType.PRODUCT, "build.gradle", "displayName", display, Confidence.HIGH)
         virtualDependency.addEvidence(EvidenceType.VERSION, "build.gradle", "version", version, Confidence.HIGHEST)
         virtualDependency.setName(name)
         virtualDependency.setVersion(version)
-        virtualDependency.setDisplayFileName(displayName ? displayName : "${groupid}:${name}:${version}")
+        virtualDependency.setDisplayFileName(display)
         virtualDependency.setPackagePath("${groupid}:${name}:${version}")
         virtualDependency.addProjectReference("${projectName}:${configurationName}")
         virtualDependency.setEcosystem("gradle")

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Aggregate.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Aggregate.groovy
@@ -18,24 +18,8 @@
 
 package org.owasp.dependencycheck.gradle.tasks
 
-import org.gradle.api.DefaultTask
-import org.gradle.api.GradleException
-import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvedArtifact
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.TaskAction
-import org.owasp.dependencycheck.Engine
-import org.owasp.dependencycheck.data.nvdcve.DatabaseException
-import org.owasp.dependencycheck.dependency.Confidence
-import org.owasp.dependencycheck.dependency.Dependency
-import org.owasp.dependencycheck.dependency.Identifier
-import org.owasp.dependencycheck.dependency.Vulnerability
-import org.owasp.dependencycheck.exception.ExceptionCollection
-import org.owasp.dependencycheck.exception.ReportException
-import org.owasp.dependencycheck.utils.Settings
-
-import static org.owasp.dependencycheck.utils.Settings.KEYS.*
 
 /**
  * Checks the projects dependencies for known vulnerabilities.

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Aggregate.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Aggregate.groovy
@@ -58,7 +58,12 @@ class Aggregate extends AbstractAnalyze {
             }.each { Configuration configuration ->
                 configuration.getResolvedConfiguration().getResolvedArtifacts().collect { ResolvedArtifact artifact ->
                     def deps = engine.scan(artifact.getFile())
-                    addInfoToDependencies(deps, artifact, "$it.name:$configuration.name")
+                    if (deps == null) {
+                        addVirtualDependency(engine, project.name, configuration.name, artifact.moduleVersion.id.group,
+                                artifact.moduleVersion.id.name, artifact.moduleVersion.id.version, artifact.id.displayName)
+                    } else {
+                        addInfoToDependencies(deps, artifact, "$it.name:$configuration.name")
+                    }
                 }
             }
         }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Analyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Analyze.groovy
@@ -57,8 +57,12 @@ class Analyze extends AbstractAnalyze {
         }.each { Configuration configuration ->
             configuration.getResolvedConfiguration().getResolvedArtifacts().collect { ResolvedArtifact artifact ->
                 def deps = engine.scan(artifact.getFile())
-                //TODO determine why deps could be null in some cases.
-                addInfoToDependencies(deps, artifact, configuration.name)
+                if (deps == null) {
+                    addVirtualDependency(engine, project.name, configuration.name, artifact.moduleVersion.id.group,
+                            artifact.moduleVersion.id.name, artifact.moduleVersion.id.version, artifact.id.displayName)
+                } else {
+                    addInfoToDependencies(deps, artifact, configuration.name)
+                }
             }
         }
     }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Analyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Analyze.groovy
@@ -18,24 +18,8 @@
 
 package org.owasp.dependencycheck.gradle.tasks
 
-import org.gradle.api.DefaultTask
-import org.gradle.api.GradleException
-import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvedArtifact
-import org.gradle.api.artifacts.ResolvedDependency
-import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.Internal
-import org.owasp.dependencycheck.Engine
-import org.owasp.dependencycheck.data.nvdcve.DatabaseException
-import org.owasp.dependencycheck.dependency.Confidence
-import org.owasp.dependencycheck.exception.ExceptionCollection
-import org.owasp.dependencycheck.exception.ReportException
-import org.owasp.dependencycheck.dependency.Dependency
-import org.owasp.dependencycheck.dependency.Identifier
-import org.owasp.dependencycheck.dependency.Vulnerability
-import org.owasp.dependencycheck.utils.Settings
-import static org.owasp.dependencycheck.utils.Settings.KEYS.*
 
 /**
  * Checks the projects dependencies for known vulnerabilities.

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Purge.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Purge.groovy
@@ -31,8 +31,10 @@ import static org.owasp.dependencycheck.utils.Settings.KEYS.DATA_DIRECTORY
  */
 class Purge extends DefaultTask {
 
-    @Internal def config = project.dependencyCheck
-    @Internal def settings
+    @Internal
+    def config = project.dependencyCheck
+    @Internal
+    def settings
 
     /**
      * Initializes the purge task.

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Update.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Update.groovy
@@ -52,8 +52,10 @@ import static org.owasp.dependencycheck.utils.Settings.KEYS.DB_PASSWORD
  */
 class Update extends DefaultTask {
 
-    @Internal def config = project.dependencyCheck
-    @Internal def settings
+    @Internal
+    def config = project.dependencyCheck
+    @Internal
+    def settings
 
     /**
      * Initializes the update task.
@@ -92,7 +94,6 @@ class Update extends DefaultTask {
             cleanup(engine)
         }
     }
-
 
     /**
      * Initializes the settings; if the setting is not configured


### PR DESCRIPTION
Resolves Issue #62 

When a dependency is scanned but no file type analyzer exists within the engine for the given dependency type a virtual dependency is used instead.