### PR TITLE
Subproject logging fix

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -435,7 +435,7 @@ abstract class AbstractAnalyze extends DefaultTask {
             if (CUTOVER_GRADLE_VERSION.compareTo(GradleVersion.current()) > 0) {
                 processConfigLegacy configuration, engine
             } else {
-                processConfigV4 configuration, engine
+                processConfigV4 project, configuration, engine
             }
         }
         boolean customScanSet = false
@@ -472,9 +472,10 @@ abstract class AbstractAnalyze extends DefaultTask {
     /**
      * Process the incoming artifacts for the given project's configurations using APIs introduced in gradle 4.0+.
      * @param project the project to analyze
+     * @param configuration a particular configuration of the project to analyze
      * @param engine the dependency-check engine
      */
-    protected void processConfigV4(Configuration configuration, Engine engine) {
+    protected void processConfigV4(Project project, Configuration configuration, Engine engine) {
         String projectName = project.name
         String scope = "$projectName:$configuration.name"
 


### PR DESCRIPTION
Explicitly pass in the project reference otherwise projectName is always from the root project even if subproject is analyzing. It is confusing when enabling info level logger.