### PR TITLE
Change to reference the new properties from cve extension.

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -191,8 +191,8 @@ abstract class AbstractAnalyze extends DefaultTask {
         settings.setStringIfNotEmpty(DB_CONNECTION_STRING, config.data.connectionString)
         settings.setStringIfNotEmpty(DB_USER, config.data.username)
         settings.setStringIfNotEmpty(DB_PASSWORD, config.data.password)
-        settings.setStringIfNotEmpty(CVE_MODIFIED_JSON, config.cve.cveUrlModified)
-        settings.setStringIfNotEmpty(CVE_BASE_JSON, config.cve.cveUrlBase)
+        settings.setStringIfNotEmpty(CVE_MODIFIED_JSON, config.cve.urlModified)
+        settings.setStringIfNotEmpty(CVE_BASE_JSON, config.cve.urlBase)
         settings.setBooleanIfNotNull(DOWNLOADER_QUICK_QUERY_TIMESTAMP, config.quickQueryTimestamp)
 
         if (config.cveValidForHours != null) {

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Update.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Update.groovy
@@ -110,8 +110,8 @@ class Update extends DefaultTask {
         settings.setStringIfNotEmpty(DB_CONNECTION_STRING, config.data.connectionString)
         settings.setStringIfNotEmpty(DB_USER, config.data.username)
         settings.setStringIfNotEmpty(DB_PASSWORD, config.data.password)
-        settings.setStringIfNotEmpty(CVE_MODIFIED_JSON, config.cve.cveUrlModified)
-        settings.setStringIfNotEmpty(CVE_BASE_JSON, config.cve.cveUrlBase)
+        settings.setStringIfNotEmpty(CVE_MODIFIED_JSON, config.cve.urlModified)
+        settings.setStringIfNotEmpty(CVE_BASE_JSON, config.cve.urlBase)
 
         settings.setStringIfNotEmpty(PROXY_SERVER, config.proxy.server)
         settings.setBooleanIfNotNull(DOWNLOADER_QUICK_QUERY_TIMESTAMP, config.quickQueryTimestamp)


### PR DESCRIPTION
Hi @jeremylong 

Thanks very much for reviewing this pull request. 

While running the task dependencyCheckAggregate, it threw an exception _Could not get unknown property 'cveUrlModified' for object of type org.owasp.dependencycheck.gradle.extension.CveExtension_. Probably those references did not get updated during refactor. 

Cheers,
Yun