### PR TITLE
Add the ability to exclude subprojects while running dependencyCheckAggregate.

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
@@ -125,6 +125,18 @@ class DependencyCheckExtension {
      */
     List<String> skipConfigurations = []
     /**
+     * Paths of the projects to scan.
+     *
+     * This is mutually exclusive with the skipProjects property.
+     */
+    List<String> scanProjects = []
+    /**
+     * Paths of the projects to skip when scanning.
+     *
+     * This is mutually exclusive with the scanProjects property.
+     */
+    List<String> skipProjects = []
+    /**
      * The artifact types that will be analyzed in the gradle build.
      */
     List<String> analyzedTypes = ['jar', 'aar', 'js', 'war', 'ear', 'zip']

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -148,6 +148,9 @@ abstract class AbstractAnalyze extends DefaultTask {
         if (config.scanConfigurations && config.skipConfigurations) {
             throw new IllegalArgumentException("you can only specify one of scanConfigurations or skipConfigurations")
         }
+        if (config.scanProjects && config.skipProjects) {
+            throw new IllegalArgumentException("you can only specify one of scanProjects or skipProjects")
+        }
     }
 
     /**
@@ -319,6 +322,23 @@ abstract class AbstractAnalyze extends DefaultTask {
                     + "See the dependency-check report for more details.%n%n", config.failBuildOnCVSS, vulnerabilities)
             throw new GradleException(msg)
         }
+    }
+
+    /**
+     * Checks whether the given project should be scanned
+     * because either scanProjects is empty or it contains the
+     * project's path.
+     */
+    def shouldBeScanned(Project project) {
+        !config.scanProjects || config.scanProjects.contains(project.path)
+    }
+
+    /**
+     * Checks whether the given project should be skipped
+     * because skipProjects contains the project's path.
+     */
+    def shouldBeSkipped(Project project) {
+        config.skipProjects.contains(project.path)
     }
 
     /**

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Aggregate.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Aggregate.groovy
@@ -37,7 +37,9 @@ class Aggregate extends AbstractAnalyze {
     def scanDependencies(engine) {
         logger.lifecycle("Verifying dependencies for project ${currentProjectName}")
         project.rootProject.allprojects.each { Project project ->
-            processConfigurations(project, engine)
+            if (shouldBeScanned(project) && !shouldBeSkipped(project)) {
+                processConfigurations(project, engine)
+            }
         }
     }
 }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Analyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Analyze.groovy
@@ -31,8 +31,10 @@ class Analyze extends AbstractAnalyze {
      * Loads the projects dependencies into the dependency-check analysis engine.
      */
     def scanDependencies(engine) {
-        logger.lifecycle("Verifying dependencies for project ${currentProjectName}")
-        processConfigurations(project, engine)
+        if (shouldBeScanned(project) && !shouldBeSkipped(project)) {
+            logger.lifecycle("Verifying dependencies for project ${currentProjectName}")
+            processConfigurations(project, engine)
+        }
     }
 
 }

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
@@ -75,6 +75,8 @@ class DependencyCheckGradlePluginSpec extends Specification {
         project.dependencyCheck.quickQueryTimestamp == null
         project.dependencyCheck.scanConfigurations == []
         project.dependencyCheck.skipConfigurations == []
+        project.dependencyCheck.scanProjects == []
+        project.dependencyCheck.skipProjects == []
         project.dependencyCheck.skipTestGroups == true
         project.dependencyCheck.suppressionFile == null
     }
@@ -112,6 +114,8 @@ class DependencyCheckGradlePluginSpec extends Specification {
 
             scanConfigurations = ['a']
             skipConfigurations = ['b']
+            scanProjects = ['a']
+            skipProjects = ['b']
             skipTestGroups = false
 
             suppressionFile = './src/config/suppression.xml'
@@ -129,6 +133,8 @@ class DependencyCheckGradlePluginSpec extends Specification {
         project.dependencyCheck.quickQueryTimestamp == false
         project.dependencyCheck.scanConfigurations == ['a']
         project.dependencyCheck.skipConfigurations == ['b']
+        project.dependencyCheck.scanProjects == ['a']
+        project.dependencyCheck.skipProjects == ['b']
         project.dependencyCheck.skipTestGroups == false
         project.dependencyCheck.suppressionFile == './src/config/suppression.xml'
         project.dependencyCheck.suppressionFiles == ['./src/config/suppression1.xml', './src/config/suppression2.xml']
@@ -146,6 +152,18 @@ class DependencyCheckGradlePluginSpec extends Specification {
             skipConfigurations = ['b']
         }
         task = project.tasks.findByName(DependencyCheckPlugin.ANALYZE_TASK).analyze()
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def 'scanProjects and skipProjects are mutually exclusive'() {
+        when:
+        project.dependencyCheck {
+            scanProjects = ['a']
+            skipProjects = ['b']
+        }
+        task = project.tasks.findByName(DependencyCheckPlugin.AGGREGATE_TASK).analyze()
 
         then:
         thrown(IllegalArgumentException)


### PR DESCRIPTION
Hi @jeremylong 

We are trying to roll out the dependency check within the company. We thought it would be good if the plugin is able to exclude some subprojects while running dependencyCheckAggregate so that the resulting report only includes vulnerabilities for the projects that we care about.

Thanks very much for your consideration.

Regards,
Yun