### PR TITLE
Configure default H2 database directory using gradleUserHome

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPlugin.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPlugin.groovy
@@ -62,7 +62,7 @@ class DependencyCheckPlugin implements Plugin<Project> {
         def ext = project.extensions.create(CHECK_EXTENSION_NAME, DependencyCheckExtension, project)
         ext.extensions.create(PROXY_EXTENSION_NAME, ProxyExtension)
         ext.extensions.create(CVE_EXTENSION_NAME, CveExtension)
-        ext.extensions.create(DATA_EXTENSION_NAME, DataExtension)
+        ext.extensions.create(DATA_EXTENSION_NAME, DataExtension, project)
         def analyzers = ext.extensions.create(ANALYZERS_EXTENSION_NAME, AnalyzerExtension)
         analyzers.extensions.create('retirejs', RetireJSExtension)
         analyzers.extensions.create('artifactory', ArtifactoryExtension)

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DataExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DataExtension.groovy
@@ -18,14 +18,21 @@
 
 package org.owasp.dependencycheck.gradle.extension
 
+import org.gradle.api.Project
+
 /**
  * The update data configuration extension. Any value not configured will use the dependency-check-core defaults.
  */
 class DataExtension {
+    
+    DataExtension(Project project) {
+        directory = "${project.gradle.gradleUserHomeDir}/dependency-check-data/4.0"
+    }
+
     /**
      * The directory to store the H2 database that contains the cache of the NVD CVE data.
      */
-    String directory="[JAR]/../../dependency-check-data/4.0"
+    String directory;
     /**
      * The connection string to the database.
      */

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
@@ -21,6 +21,8 @@ package org.owasp.dependencycheck.gradle
 import org.gradle.api.Task
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
+import org.owasp.dependencycheck.gradle.extension.DataExtension
+import org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension
 import spock.lang.Specification
 
 class DependencyCheckGradlePluginSpec extends Specification {
@@ -35,6 +37,14 @@ class DependencyCheckGradlePluginSpec extends Specification {
     def 'dependencyCheck extension exists'() {
         expect:
         project.extensions.findByName('dependencyCheck')
+    }
+
+    def 'dependencyCheck extension has correct default data configuration'() {
+        setup:
+        DependencyCheckExtension extension = project.extensions.findByName('dependencyCheck')
+        
+        expect:
+        extension.data.directory == "${project.gradle.gradleUserHomeDir}/dependency-check-data/4.0"
     }
 
     def "dependencyCheckAnalyze task exists"() {


### PR DESCRIPTION
Populate `DataExtension` from `project.gradle.gradleUserHomeDir`. 

See issue https://github.com/jeremylong/dependency-check-gradle/issues/136.

Added a test, however was not able to compare against the system property `user.home` as it is all temp paths in the unit test. For manual validation of this property being the correct one, see documentation, or try execute

```groovy
task('hello') {
    doLast {
        println project.gradle.gradleUserHomeDir
    }
}
```