### PR TITLE
Only run dependencyCheckAggregate on rootproject if it has the plugin, otherwise use subprojects

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Aggregate.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Aggregate.groovy
@@ -19,12 +19,12 @@
 package org.owasp.dependencycheck.gradle.tasks
 
 import org.gradle.api.Project
+import org.owasp.dependencycheck.gradle.DependencyCheckPlugin
 
 /**
  * Checks the projects dependencies for known vulnerabilities.
  */
 class Aggregate extends AbstractAnalyze {
-
 
     Aggregate() {
         group = 'OWASP dependency-check'
@@ -36,9 +36,17 @@ class Aggregate extends AbstractAnalyze {
      */
     def scanDependencies(engine) {
         logger.lifecycle("Verifying dependencies for project ${currentProjectName}")
-        project.rootProject.allprojects.each { Project project ->
-            if (shouldBeScanned(project) && !shouldBeSkipped(project)) {
-                processConfigurations(project, engine)
+        if (project.rootProject.plugins.hasPlugin(DependencyCheckPlugin)) {
+            scanProject(project.rootProject.allprojects, engine)
+        } else {
+            scanProject(project.subprojects, engine)
+        }
+    }
+
+    private def scanProject(Set<Project> projects, engine) {
+        projects.each { Project Project ->
+            if (shouldBeScanned(Project) && !shouldBeSkipped(Project)) {
+                processConfigurations(Project, engine)
             }
         }
     }


### PR DESCRIPTION
The current functionality is awkward in the following situation:
`root/foo` has dependencyCheckAggregate
`root` does not
`root/bar` does not

With that setup dependencyCheckAggregate would include `root` and `root/bar`, with this PR we check if the root project has the plugin, if not we just scan the projects below this one, meaning that `root/foo/bar` will be included but not `root/bar/cafe`