### PR TITLE
Fixes #132 : Add config option to skip dependency groups

### DIFF
--- a/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
+++ b/src/integTest/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
@@ -80,6 +80,17 @@ class DependencyCheckConfigurationSelectionIntegSpec extends Specification {
         result.task(":$ANALYZE_TASK").outcome == SUCCESS
     }
 
+    def "groups are skipped if blacklisted"() {
+        given:
+        copyBuildFileIntoProjectDir('skipGroups.gradle')
+
+        when:
+        def result = executeTaskAndGetResult(ANALYZE_TASK, true)
+
+        then:
+        result.task(":$ANALYZE_TASK").outcome == SUCCESS
+    }
+
     def "aggregate task aggregates"() {
         given:
         copyBuildFileIntoProjectDir('aggregateParent.gradle')

--- a/src/integTest/resources/skipGroups.gradle
+++ b/src/integTest/resources/skipGroups.gradle
@@ -18,6 +18,6 @@ dependencies {
 }
 
 dependencyCheck {
-    skipGroups = ['commons-collections', 'commons-httpclient', 'commons-fileupload']
+    skipGroups = ['commons-collections', 'commons-httpclient', 'commons-file']
     failBuildOnCVSS = 0
 }

--- a/src/integTest/resources/skipGroups.gradle
+++ b/src/integTest/resources/skipGroups.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id 'org.owasp.dependencycheck'
+    id 'java'
+}
+
+sourceCompatibility = 1.5
+version = '1.0'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    compile group: 'commons-collections', name: 'commons-collections', version: '3.2'
+    compile group: 'commons-httpclient', name: 'commons-httpclient', version: '3.1'
+    compile group: 'commons-fileupload', name: 'commons-fileupload', version: '1.3.1'
+}
+
+dependencyCheck {
+    skipGroups = ['commons-collections', 'commons-httpclient', 'commons-fileupload']
+    failBuildOnCVSS = 0
+}

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
@@ -158,6 +158,10 @@ class DependencyCheckExtension {
      */
     List<String> skipProjects = []
     /**
+     * Groups of the modules to skip when scanning.
+     */
+    List<String> skipGroups = []
+    /**
      * The artifact types that will be analyzed in the gradle build.
      */
     List<String> analyzedTypes = ['jar', 'aar', 'js', 'war', 'ear', 'zip']

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
@@ -158,7 +158,9 @@ class DependencyCheckExtension {
      */
     List<String> skipProjects = []
     /**
-     * Groups of the modules to skip when scanning.
+     * Group prefixes of the modules to skip when scanning.
+     *
+     * The 'project' prefix can be used to skip all internal dependencies from multi-project build.
      */
     List<String> skipGroups = []
     /**

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
@@ -86,6 +86,7 @@ class DependencyCheckGradlePluginSpec extends Specification {
         project.dependencyCheck.skipConfigurations == []
         project.dependencyCheck.scanProjects == []
         project.dependencyCheck.skipProjects == []
+        project.dependencyCheck.skipGroups == []
         project.dependencyCheck.skipTestGroups == true
         project.dependencyCheck.suppressionFile == null
     }
@@ -132,6 +133,7 @@ class DependencyCheckGradlePluginSpec extends Specification {
             skipConfigurations = ['b']
             scanProjects = ['a']
             skipProjects = ['b']
+            skipGroups = ['b']
             skipTestGroups = false
 
             suppressionFile = './src/config/suppression.xml'
@@ -153,6 +155,7 @@ class DependencyCheckGradlePluginSpec extends Specification {
         project.dependencyCheck.skipConfigurations == ['b']
         project.dependencyCheck.scanProjects == ['a']
         project.dependencyCheck.skipProjects == ['b']
+        project.dependencyCheck.skipGroups == ['b']
         project.dependencyCheck.skipTestGroups == false
         project.dependencyCheck.suppressionFile == './src/config/suppression.xml'
         project.dependencyCheck.suppressionFiles == ['./src/config/suppression1.xml', './src/config/suppression2.xml']


### PR DESCRIPTION
This PR adds the ability to configure which dependency group prefixes should be skipped when scanning.

- Added `skipGroups` option to config
- Skips defined group prefixes when scanning
- Added integration test
- Extended unit tests

Limitation:
- I'm checking the group of the dependency on resolved artifact identifier which is:
  - usable for standard external dependencies - id is e.g. `org.apache.logging.log4j:log4j-api:2.13.3` which can be skipped by e.g. `org.apache.logging` prefix
  - not intuitive for internal dependencies from other subprojects in multi-project build - id is e.g. `project :my-module` which can be skipped by `project` prefix along with all internal dependencies