### PR TITLE
Configuration Cache Support

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -65,6 +65,14 @@ abstract class AbstractAnalyze extends ConfiguredTask {
     @Internal
     String currentProjectName = project.getName()
 
+    @Internal
+    String currentProjectGroup = project.getGroup()
+
+    @Internal
+    String currentProjectVersion = project.getVersion().toString()
+
+
+
     /**
      * Gets the projects display name. Project.getDisplayName() has been
      * introduced with Gradle 3.3, thus we need to check for the method's
@@ -123,8 +131,8 @@ abstract class AbstractAnalyze extends ConfiguredTask {
             try {
                 String name = currentProjectName
                 String displayName = currentProjectDisplayName
-                String groupId = project.getGroup()
-                String version = project.getVersion().toString()
+                String groupId = currentProjectGroup
+                String version = currentProjectVersion
                 File output = new File(config.outputDirectory)
                 for (String f : getReportFormats(config.format, config.formats)) {
                     engine.writeReports(displayName, groupId, name, version, output, f, exCol)
@@ -219,6 +227,7 @@ abstract class AbstractAnalyze extends ConfiguredTask {
 
     /**
      * Loads the projects dependencies into the dependency-check analysis engine.
+     * Runs at execution time
      */
     abstract scanDependencies(Engine engine)
 
@@ -404,6 +413,7 @@ abstract class AbstractAnalyze extends ConfiguredTask {
 
     /**
      * Process the incoming artifacts for the given project's configurations.
+     * Runs at execution time.
      * @param project the project to analyze
      * @param engine the dependency-check engine
      */
@@ -416,7 +426,7 @@ abstract class AbstractAnalyze extends ConfiguredTask {
             if (CUTOVER_GRADLE_VERSION.compareTo(GradleVersion.current()) > 0) {
                 processConfigLegacy configuration, engine
             } else {
-                processConfigV4 project.name, configuration, engine, true
+                processConfigV4 currentProjectName, configuration, engine, true
             }
         }
     }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Aggregate.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Aggregate.groovy
@@ -39,6 +39,7 @@ class Aggregate extends AbstractAnalyze {
 
     /**
      * Loads the projects dependencies into the dependency-check analysis engine.
+     * Runs at execution time
      */
     def scanDependencies(Engine engine) {
         logger.lifecycle("Verifying dependencies for project ${currentProjectName}")

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Analyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Analyze.groovy
@@ -41,6 +41,7 @@ class Analyze extends AbstractAnalyze {
 
     /**
      * Loads the projects dependencies into the dependency-check analysis engine.
+     * Runs at execution time
      */
     def scanDependencies(Engine engine) {
         if (shouldBeScanned(currentProjectPath) && !shouldBeSkipped(currentProjectPath)) {


### PR DESCRIPTION
Fixes https://github.com/dependency-check/dependency-check-gradle/issues/339 (WIP)

There are a couple challenges I noticed ahead:

1. `project.group` and `project.version` are used in the task action. These values could be changed at any point during the configuration phase and AFAIK they are not observable. Therefore, getting them when the plugin is applied risks the possibility that the consumer changes them after.
2. While configuration resolution results are in fact configuration cachable, it could possibility be a heavy amount of work to get this working properly and performantly

I don't know if when if ever I'll get around to finishing this PR, so anyone should feel free to complete it. Just remove usages of `project` from task action and navigate the challenges above.