### PR TITLE
fix: Remove noisy JCS3 logging consistent with other ODC impls

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     api(libs.owasp.dependencyCheck.utils)
     api(libs.openVuln.clients)
     api(libs.slack.webhook)
+    implementation(libs.jcs3.slf4j)
 
     testImplementation(gradleTestKit())
     testImplementation(libs.spock.core) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ owasp-dependencyCheck-core = { module = 'org.owasp:dependency-check-core', versi
 owasp-dependencyCheck-utils = { module = 'org.owasp:dependency-check-utils', version.ref = 'odc' }
 openVuln-clients = { module = 'io.github.jeremylong:open-vulnerability-clients', version = '6.1.7' }
 slack-webhook = { module = 'net.gpedro.integrations.slack:slack-webhook', version = '1.4.0' }
+jcs3-slf4j = { module = 'io.github.jeremylong:jcs3-slf4j', version = '1.0.5' }
 
 junit-jupiter-api = { module = 'org.junit.jupiter:junit-jupiter-api', version.ref = 'junit' }
 junit-jupiter-params = { module = 'org.junit.jupiter:junit-jupiter-params', version.ref = 'junit' }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPlugin.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPlugin.groovy
@@ -19,6 +19,7 @@
 package org.owasp.dependencycheck.gradle
 
 import groovy.transform.CompileStatic
+import io.github.jeremylong.jcs3.slf4j.Slf4jAdapter
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -28,9 +29,19 @@ import org.owasp.dependencycheck.gradle.tasks.Aggregate
 import org.owasp.dependencycheck.gradle.tasks.Analyze
 import org.owasp.dependencycheck.gradle.tasks.Purge
 import org.owasp.dependencycheck.gradle.tasks.Update
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 @CompileStatic
 class DependencyCheckPlugin implements Plugin<Project> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DependencyCheckPlugin.class);
+    static {
+        // Quiet noisy loggers
+        System.setProperty("jcs.logSystem", "slf4j")
+        if (!LOGGER.isDebugEnabled()) {
+            Slf4jAdapter.muteLogging(true);
+        }
+    }
 
     static final GradleVersion MINIMUM_GRADLE_VERSION = GradleVersion.version("4.0")
     static final GradleVersion REGISTER_TASK_GRADLE_VERSION = GradleVersion.version("4.9")


### PR DESCRIPTION
Removes all the noisy logs (consistent with how already addressed on the CLI, maven plugin etc).

Removes stuff like this:
```
Region [NODEAUDIT] : Not alive and dispose was called, filename: NODEAUDIT
Region [CENTRAL] : Not alive and dispose was called, filename: CENTRAL
Region [POM] : Not alive and dispose was called, filename: POM
```