### PR TITLE
fix!: Change default output directory to `build/reports/dependency-check` to avoid clash with other reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ Once gradle plugin applied, run following gradle task to check dependencies:
 gradle dependencyCheckAnalyze --info
 ```
 
-The reports will be generated automatically under `build/reports` directory.
+The reports will be generated automatically under `build/reports/dependency-check` by default; resolved via Gradle's reporting
+directory (`project.reporting.baseDirectory.dir("dependency-check")`).
 
-If your project includes multiple sub-projects, the report will be generated for each sub-project in their own `build/reports`.
+If your project includes multiple sub-projects, the report will be generated for each sub-project in their own `project.reporting.baseDirectory.dir("dependency-check")` location.
 
 ### Multiple Configurations
 
@@ -53,20 +54,20 @@ Some projects may require multiple dependency-check configurations. This is supp
 
 ```groovy
 plugins {
-    id 'java'
-    id 'org.owasp.dependencycheck' version '12.2.2'
+  id 'java'
+  id 'org.owasp.dependencycheck' version '12.2.2'
 }
 
 tasks.register('dependencyCheckRelease', org.owasp.dependencycheck.gradle.tasks.Analyze) {
-    dependencyCheck {
-        failBuildOnCVSS = 9.0
-    }
+  dependencyCheck {
+    failBuildOnCVSS = 9.0
+  }
 }
 
 tasks.register('dependencyCheckCI', org.owasp.dependencycheck.gradle.tasks.Analyze) {
-    dependencyCheck {
-        failBuildOnCVSS = 3.0
-    }
+  dependencyCheck {
+    failBuildOnCVSS = 3.0
+  }
 }
 ```
 
@@ -79,13 +80,13 @@ to specific versions compatible with all plugins in your build.
 For example in `buildSrc/build.gradle`
 ```groovy
 dependencies {
-    constraints {
-        // org.owasp.dependencycheck needs at least this version of jackson. Other plugins pull in older versions..
-        add("implementation", "com.fasterxml.jackson:jackson-bom:2.21.2")
-        // org.owasp.dependencycheck needs these versions. Other plugins pull in older versions..
-        add("implementation", "org.apache.commons:commons-lang3:3.20.0")
-        add("implementation", "org.apache.commons:commons-text:1.15.0")
-    }
+  constraints {
+    // org.owasp.dependencycheck needs at least this version of jackson. Other plugins pull in older versions..
+    add("implementation", "com.fasterxml.jackson:jackson-bom:2.21.2")
+    // org.owasp.dependencycheck needs these versions. Other plugins pull in older versions..
+    add("implementation", "org.apache.commons:commons-lang3:3.20.0")
+    add("implementation", "org.apache.commons:commons-text:1.15.0")
+  }
 }
 ```
 
@@ -116,7 +117,7 @@ buildscript {
 }
 
 allprojects {
-    apply plugin: 'org.owasp.dependencycheck'
+  apply plugin: 'org.owasp.dependencycheck'
 }
 ```
 
@@ -135,7 +136,7 @@ buildscript {
 }
 
 subprojects {
-    apply plugin: 'org.owasp.dependencycheck'
+  apply plugin: 'org.owasp.dependencycheck'
 }
 ```
 
@@ -147,15 +148,19 @@ For aggregate scan, apply the plugin either on the root project or alternatively
 
 ### How to customize the report directory?
 
-By default, all reports will be placed under `build/reports` folder, to change the default reporting folder name modify the configuration section like this:
+To change the default report folder, modify the configuration section like this:
 
 ```groovy
 subprojects {
-    apply plugin: 'org.owasp.dependencycheck'
+  apply plugin: 'org.owasp.dependencycheck'
 
-    dependencyCheck {
-        outputDirectory = "$buildDir/security-report"
-    }
+  dependencyCheck {
+    // To somewhere in the build directory
+    outputDirectory = layout.buildDirectory.dir('security-report')
+  
+    // or relative to the global reporting directory:
+    outputDirectory = reporting.baseDirectory.dir('security-report')
+  }
 }
 ```
 
@@ -163,15 +168,15 @@ subprojects {
 
 ```kotlin
 plugins {
-    id("org.owasp.dependencycheck") version "12.2.2" apply false
+  id("org.owasp.dependencycheck") version "12.2.2" apply false
 }
 
 allprojects {
-    apply(plugin = "org.owasp.dependencycheck")
+  apply(plugin = "org.owasp.dependencycheck")
 }
 
 configure<org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension> {
-    format = org.owasp.dependencycheck.reporting.ReportGenerator.Format.ALL.toString()
+  format = org.owasp.dependencycheck.reporting.ReportGenerator.Format.ALL.toString()
 }
 ```
 

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPlugin.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPlugin.groovy
@@ -21,6 +21,7 @@ package org.owasp.dependencycheck.gradle
 import groovy.transform.CompileStatic
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.plugins.ReportingBasePlugin
 import org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension
 import org.owasp.dependencycheck.gradle.tasks.Aggregate
 import org.owasp.dependencycheck.gradle.tasks.Analyze
@@ -46,6 +47,7 @@ class DependencyCheckPlugin implements Plugin<Project> {
     }
 
     void apply(Project project) {
+        project.pluginManager.apply(ReportingBasePlugin)
         initializeConfigurations(project)
         registerTasks(project)
     }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
@@ -202,7 +202,7 @@ class DependencyCheckExtension {
     /**
      * The directory where the reports will be written. Defaults to `project.reporting.baseDirectory.dir("dependency-check")`.
      */
-    @InputDirectory
+    @Input
     @Optional
     DirectoryProperty getOutputDirectory() {
         return outputDirectory

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFiles
@@ -120,10 +121,12 @@ class DependencyCheckExtension {
     DependencyCheckExtension(Project project, ObjectFactory objects) {
         this.project = project;
 
+        def reporting = project.extensions.getByType(ReportingExtension)
+
         this.scanBuildEnv = objects.property(Boolean).convention(false)
         this.scanDependencies = objects.property(Boolean).convention(true)
         this.failOnError = objects.property(Boolean).convention(true)
-        this.outputDirectory = objects.directoryProperty().convention(project.layout.buildDirectory.dir("reports"))
+        this.outputDirectory = objects.directoryProperty().convention(reporting.baseDirectory.dir("dependency-check"))
         this.suppressionFile = objects.property(String)
         this.suppressionFiles = objects.listProperty(String).convention([])
         this.suppressionFileUser = objects.property(String)
@@ -197,7 +200,7 @@ class DependencyCheckExtension {
     }
 
     /**
-     * The directory where the reports will be written. Defaults to 'build/reports'.
+     * The directory where the reports will be written. Defaults to `project.reporting.baseDirectory.dir("dependency-check")`.
      */
     @InputDirectory
     @Optional

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
@@ -20,6 +20,7 @@ package org.owasp.dependencycheck.gradle
 
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.reporting.ReportingExtension
 import org.gradle.testfixtures.ProjectBuilder
 import org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension
 import org.owasp.dependencycheck.gradle.extension.NexusExtension
@@ -87,7 +88,7 @@ class DependencyCheckGradlePluginSpec extends Specification {
         project.dependencyCheck.nvd.apiKey.getOrNull() == null
         project.dependencyCheck.nvd.delay.getOrNull() == null
         project.dependencyCheck.nvd.maxRetryCount.getOrNull() == null
-        project.dependencyCheck.outputDirectory.get().asFile == project.layout.buildDirectory.dir('reports').get().asFile
+        project.dependencyCheck.outputDirectory.get().asFile == project.file('build/reports/dependency-check')
         project.dependencyCheck.scanConfigurations.get() == []
         project.dependencyCheck.skipConfigurations.get() == []
         project.dependencyCheck.scanProjects.get() == []
@@ -128,7 +129,7 @@ class DependencyCheckGradlePluginSpec extends Specification {
             analyzers.retirejs.filters = ['filter1', 'filter2']
             analyzers.retirejs.filterNonVulnerable = true
 
-            outputDirectory = 'outputDirectory'
+            outputDirectory = project.reporting.baseDirectory.dir('outputDirectory')
 
             scanConfigurations = ['a']
             skipConfigurations = ['b']
@@ -173,7 +174,7 @@ class DependencyCheckGradlePluginSpec extends Specification {
         project.dependencyCheck.hostedSuppressions.url.get() == 'suppressionsurl'
         project.dependencyCheck.hostedSuppressions.validForHours.get() == 5
         project.dependencyCheck.hostedSuppressions.forceupdate.get() == true
-        project.dependencyCheck.outputDirectory.get().asFile == project.file('outputDirectory')
+        project.dependencyCheck.outputDirectory.get().asFile == project.file('build/reports/outputDirectory')
         project.dependencyCheck.scanConfigurations.get() == ['a']
         project.dependencyCheck.skipConfigurations.get() == ['b']
         project.dependencyCheck.scanProjects.get() == ['a']


### PR DESCRIPTION
- fixes #482 

Note that this is a _mildly breaking change_ so might want to consider that, although if people are sensitive to the location, you'd hope they'd configure it specifically. Technically `12.1.8` was also a mildly breaking change when the directory got marked as an `@OutputDirectory` as it made Gradle explicitly aware of the ordering problems between tasks, rather than discovering it later.

Setting to the current `build/reports` directory tends to break task caching for other plugins since many of them put things into `/reports` including Gradle's `reports/problems/problems-report.html`, test reports into `reports/tests`. When ODC writes things there, Gradle isn't sure what to do as it implies ordering issues between tasks, either causing tasks to unnecessarily re-run, or users to need to define dependencies between tasks, which is quite confusing.

It requires a fair bit of Gradle experience to figure out that the ODC directory needs to be changed to work around it.

- I considered declaring a set of `@OutputFile`s instead (which would be backward compatible) but that's not so safe/easy to do with the interface to ODC.
- Changed `@InputDirectory` -> `@Input`. `@InputDirectory` or `@OutputDirectory` [are for directories whose contents you care about](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/InputDirectory.html), and where it should cause the task to re-run if cached. In this case we only care about the path, not the contents.

TODO afterwards
- [ ] Update website documentation