### PR TITLE
chore: remove unnecessary upstreamed JCS logging configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,6 @@ dependencies {
     api(libs.owasp.dependencyCheck.utils)
     api(libs.openVuln.clients)
     api(libs.slack.webhook)
-    implementation(libs.jcs3.slf4j)
 
     testImplementation(gradleTestKit())
     testImplementation(libs.spock.core) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,6 @@ owasp-dependencyCheck-core = { module = 'org.owasp:dependency-check-core', versi
 owasp-dependencyCheck-utils = { module = 'org.owasp:dependency-check-utils', version.ref = 'odc' }
 openVuln-clients = { module = 'io.github.jeremylong:open-vulnerability-clients', version = '6.1.7' }
 slack-webhook = { module = 'net.gpedro.integrations.slack:slack-webhook', version = '1.4.0' }
-jcs3-slf4j = { module = 'io.github.jeremylong:jcs3-slf4j', version = '1.0.5' }
 
 junit-jupiter-api = { module = 'org.junit.jupiter:junit-jupiter-api', version.ref = 'junit' }
 junit-jupiter-params = { module = 'org.junit.jupiter:junit-jupiter-params', version.ref = 'junit' }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPlugin.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPlugin.groovy
@@ -19,31 +19,18 @@
 package org.owasp.dependencycheck.gradle
 
 import groovy.transform.CompileStatic
-import io.github.jeremylong.jcs3.slf4j.Slf4jAdapter
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.util.GradleVersion
 import org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension
-import org.owasp.dependencycheck.gradle.tasks.AbstractAnalyze
 import org.owasp.dependencycheck.gradle.tasks.Aggregate
 import org.owasp.dependencycheck.gradle.tasks.Analyze
 import org.owasp.dependencycheck.gradle.tasks.Purge
 import org.owasp.dependencycheck.gradle.tasks.Update
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 
 @CompileStatic
 class DependencyCheckPlugin implements Plugin<Project> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DependencyCheckPlugin.class);
-    static {
-        // Quiet noisy loggers
-        System.setProperty("jcs.logSystem", "slf4j")
-        if (!LOGGER.isDebugEnabled()) {
-            Slf4jAdapter.muteLogging(true);
-        }
-    }
-
     static final GradleVersion MINIMUM_GRADLE_VERSION = GradleVersion.version("4.0")
     static final GradleVersion REGISTER_TASK_GRADLE_VERSION = GradleVersion.version("4.9")
 


### PR DESCRIPTION
https://github.com/dependency-check/DependencyCheck/pull/8117 upstreams this configuration to dependency-check-core, so this is no longer necessary. It wasn't always working correctly/deterministically for some reason (possibly Gradle's internal use of slf4j?), so hopefully this addresses the situation more reliably for the Gradle plugin.

Pending merge upstream.