### PR TITLE
feat: task configuration

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AdditionalCpe.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AdditionalCpe.groovy
@@ -4,6 +4,7 @@ import org.gradle.api.Named
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 
 import javax.inject.Inject
@@ -28,6 +29,7 @@ class AdditionalCpe implements Named {
     /**
      * Name assigned to the CPE entry during configuration.
      */
+    @Internal
     @Override
     String getName() {
         return name

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzeTaskConfig.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzeTaskConfig.groovy
@@ -12,41 +12,104 @@ import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 
 abstract class AnalyzeTaskConfig {
+    /**
+     * If set to true dependency-check analysis will be skipped.
+     */
     @Input
     abstract Property<Boolean> getSkip()
+    /**
+     * The default artifact types that will be analyzed.
+     */
     @Input
     abstract ListProperty<String> getAnalyzedTypes()
+    /**
+     * Fails the build if an error occurs during the dependency-check analysis.
+     */
     @Input
     abstract Property<Boolean> getFailOnError()
+    /**
+     * The report format to be generated (HTML, XML, CSV, JSON, JUNIT, SARIF, JENKINS, GITLAB, ALL).
+     */
     @Optional
     @Input
     abstract Property<String> getFormat()
+    /**
+     * A list of report formats to be generated (HTML, XML, CSV, JSON, JUNIT, SARIF, JENKINS, GITLAB, ALL).
+     */
     @Input
     abstract ListProperty<String> getFormats()
+    /**
+     * A boolean indicating whether to scan the <i>buildEnv</i>.
+     */
     @Input
     abstract Property<Boolean> getScanBuildEnv()
+    /**
+     * A boolean indicating whether to scan the <i>dependencies</i>.
+     */
     @Input
     abstract Property<Boolean> getScanDependencies()
+    /**
+     * A list of configurations that will be scanned, all other configurations are skipped.
+     * This is mutually exclusive with the {@link #getSkipConfigurations skipConfigurations} property.
+     */
     @Input
     abstract ListProperty<String> getScanConfigurations()
+    /**
+     * A list of configurations that will be skipped.
+     * This is mutually exclusive with the {@link #getScanConfigurations scanConfigurations} property.
+     */
     @Input
     abstract ListProperty<String> getSkipConfigurations()
+    /**
+     * A list of projects that will be scanned, all other projects are skipped.
+     * The list or projects to skip must include a preceding colon: <code>scanProjects = [':app']</code>.
+     * This is mutually exclusive with the {@link #getSkipProjects skipProjects} property.
+     */
     @Input
     abstract ListProperty<String> getScanProjects()
+    /**
+     * A list of projects that will be skipped.
+     * The list or projects to skip must include a preceding colon: <code>skipProjects = [':sub1']</code>.
+     * This is mutually exclusive with the {@link #getScanProjects scanProjects} property.
+     */
     @Input
     abstract ListProperty<String> getSkipProjects()
+    /**
+     * Displays a summary of the findings.
+     */
     @Input
     abstract Property<Boolean> getShowSummary()
+    /**
+     * Specifies if the build should be failed if a CVSS score equal to or above a specified level is identified.
+     */
     @Input
     abstract Property<Number> getFailBuildOnCVSS()
+    /**
+     * Group prefixes of the modules to skip when scanning.
+     * The 'project' prefix can be used to skip all internal dependencies from multi-project build.
+     */
     @Input
     abstract ListProperty<String> getSkipGroups()
+    /**
+     * When set to true all dependency groups that being with 'test' will be skipped.
+     */
     @Input
     abstract Property<Boolean> getSkipTestGroups()
+    /**
+     * A list of directories that will be scanned for additional dependencies.
+     */
     @InputFiles
     abstract ConfigurableFileCollection getScanSet()
+    /**
+     * Additional CPE to be analyzed.
+     */
     @Nested
     abstract NamedDomainObjectContainer<AdditionalCpe> getAdditionalCpes()
+    /**
+     * Dependencycheck Engine settings.
+     * List of supported keys: {@link org.owasp.dependencycheck.utils.Settings.KEYS}
+     * @see org.owasp.dependencycheck.utils.Settings
+     */
     @Input
     abstract MapProperty<String, Object> getSettings()
     @Internal

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzeTaskConfig.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzeTaskConfig.groovy
@@ -85,7 +85,7 @@ abstract class AnalyzeTaskConfig implements DependencyCheckTaskConfig {
     @Input
     abstract ListProperty<String> getSkipGroups()
     /**
-     * When set to true all dependency groups that being with 'test' will be skipped.
+     * When set to true all dependency groups that begin with 'test' will be skipped.
      */
     @Input
     abstract Property<Boolean> getSkipTestGroups()

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzeTaskConfig.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzeTaskConfig.groovy
@@ -36,7 +36,7 @@ abstract class AnalyzeTaskConfig {
     @Input
     abstract Property<Boolean> getShowSummary()
     @Input
-    abstract Property<Float> getFailBuildOnCVSS()
+    abstract Property<Number> getFailBuildOnCVSS()
     @Input
     abstract ListProperty<String> getSkipGroups()
     @Input

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzeTaskConfig.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzeTaskConfig.groovy
@@ -1,0 +1,54 @@
+package org.owasp.dependencycheck.gradle.extension
+
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
+
+abstract class AnalyzeTaskConfig {
+    @Input
+    abstract Property<Boolean> getSkip()
+    @Input
+    abstract ListProperty<String> getAnalyzedTypes()
+    @Input
+    abstract Property<Boolean> getFailOnError()
+    @Input
+    abstract Property<String> getFormat()
+    @Input
+    abstract ListProperty<String> getFormats()
+    @Input
+    abstract Property<Boolean> getScanBuildEnv()
+    @Input
+    abstract Property<Boolean> getScanDependencies()
+    @Input
+    abstract ListProperty<String> getScanConfigurations()
+    @Input
+    abstract ListProperty<String> getSkipConfigurations()
+    @Input
+    abstract ListProperty<String> getScanProjects()
+    @Input
+    abstract ListProperty<String> getSkipProjects()
+    @Input
+    abstract Property<Boolean> getShowSummary()
+    @Input
+    abstract Property<Float> getFailBuildOnCVSS()
+    @Input
+    abstract ListProperty<String> getSkipGroups()
+    @Input
+    abstract Property<Boolean> getSkipTestGroups()
+    @InputFiles
+    abstract ConfigurableFileCollection getScanSet()
+    @Nested
+    abstract NamedDomainObjectContainer<AdditionalCpe> getAdditionalCpes()
+    @Input
+    abstract MapProperty<String, Object> getSettings()
+    @Internal
+    boolean isScanSetConfigured() {
+        !scanSet.empty
+    }
+}

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzeTaskConfig.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzeTaskConfig.groovy
@@ -3,7 +3,6 @@ package org.owasp.dependencycheck.gradle.extension
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.ListProperty
-import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
@@ -11,7 +10,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 
-abstract class AnalyzeTaskConfig {
+abstract class AnalyzeTaskConfig implements DependencyCheckTaskConfig {
     /**
      * If set to true dependency-check analysis will be skipped.
      */
@@ -22,11 +21,6 @@ abstract class AnalyzeTaskConfig {
      */
     @Input
     abstract ListProperty<String> getAnalyzedTypes()
-    /**
-     * Fails the build if an error occurs during the dependency-check analysis.
-     */
-    @Input
-    abstract Property<Boolean> getFailOnError()
     /**
      * The report format to be generated (HTML, XML, CSV, JSON, JUNIT, SARIF, JENKINS, GITLAB, ALL).
      */
@@ -105,13 +99,6 @@ abstract class AnalyzeTaskConfig {
      */
     @Nested
     abstract NamedDomainObjectContainer<AdditionalCpe> getAdditionalCpes()
-    /**
-     * Dependencycheck Engine settings.
-     * List of supported keys: {@link org.owasp.dependencycheck.utils.Settings.KEYS}
-     * @see org.owasp.dependencycheck.utils.Settings
-     */
-    @Input
-    abstract MapProperty<String, Object> getSettings()
     @Internal
     boolean isScanSetConfigured() {
         !scanSet.empty

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzeTaskConfig.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzeTaskConfig.groovy
@@ -9,6 +9,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
 
 abstract class AnalyzeTaskConfig {
     @Input
@@ -17,6 +18,7 @@ abstract class AnalyzeTaskConfig {
     abstract ListProperty<String> getAnalyzedTypes()
     @Input
     abstract Property<Boolean> getFailOnError()
+    @Optional
     @Input
     abstract Property<String> getFormat()
     @Input

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckTaskConfig.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckTaskConfig.groovy
@@ -16,5 +16,5 @@ interface DependencyCheckTaskConfig {
      * @see org.owasp.dependencycheck.utils.Settings
      */
     @Input
-    MapProperty<String, Object> getSettings()
+    abstract MapProperty<String, Object> getSettings()
 }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckTaskConfig.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckTaskConfig.groovy
@@ -1,0 +1,20 @@
+package org.owasp.dependencycheck.gradle.extension;
+
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input;
+
+interface DependencyCheckTaskConfig {
+    /**
+     * Fails the build if an error occurs during the task execution.
+     */
+    @Input
+    abstract Property<Boolean> getFailOnError()
+    /**
+     * DependencyCheck Engine settings.
+     * List of supported keys: {@link org.owasp.dependencycheck.utils.Settings.KEYS}
+     * @see org.owasp.dependencycheck.utils.Settings
+     */
+    @Input
+    MapProperty<String, Object> getSettings()
+}

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -20,6 +20,8 @@ package org.owasp.dependencycheck.gradle.tasks
 
 import com.github.packageurl.PackageURL
 import com.github.packageurl.PackageURLBuilder
+
+import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
@@ -36,6 +38,7 @@ import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.maven.MavenModule
@@ -52,6 +55,7 @@ import org.owasp.dependencycheck.dependency.Vulnerability
 import org.owasp.dependencycheck.dependency.naming.CpeIdentifier
 import org.owasp.dependencycheck.exception.ExceptionCollection
 import org.owasp.dependencycheck.exception.ReportException
+import org.owasp.dependencycheck.gradle.extension.AnalyzeTaskConfig
 import org.owasp.dependencycheck.gradle.service.SlackNotificationSenderService
 import org.owasp.dependencycheck.utils.Checksum
 import org.owasp.dependencycheck.utils.SeverityUtil
@@ -89,7 +93,34 @@ abstract class AbstractAnalyze extends ConfiguredTask {
 
     @Inject
     AbstractAnalyze(ObjectFactory objects) {
+        super(AnalyzeTaskConfig)
+        config.skip.set(extension.skip)
+        config.analyzedTypes.set(extension.analyzedTypes)
+        config.format.set(extension.format)
+        config.formats.set(extension.formats)
+        config.scanBuildEnv.set(extension.scanBuildEnv)
+        config.scanDependencies.set(extension.scanDependencies)
+        config.scanConfigurations.set(extension.scanConfigurations)
+        config.skipConfigurations.set(extension.skipConfigurations)
+        config.scanProjects.set(extension.scanProjects)
+        config.skipProjects.set(extension.skipProjects)
+        config.showSummary.set(extension.showSummary)
+        config.failBuildOnCVSS.set(extension.failBuildOnCVSS)
+        config.skipGroups.set(extension.skipGroups)
+        config.skipTestGroups.set(extension.skipTestGroups)
+        config.scanSet.from(extension.scanSet)
+        config.additionalCpes.addAll(extension.additionalCpes)
         outputDir = objects.directoryProperty().convention(extension.outputDirectory)
+    }
+
+    @Nested
+    @Override
+    AnalyzeTaskConfig getConfig() {
+        (AnalyzeTaskConfig) super.config
+    }
+
+    def config(Action<? super AnalyzeTaskConfig> action) {
+        action.execute(config)
     }
 
     /**

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -89,7 +89,7 @@ abstract class AbstractAnalyze extends ConfiguredTask {
 
     @Inject
     AbstractAnalyze(ObjectFactory objects) {
-        outputDir = objects.directoryProperty().convention(config.outputDirectory)
+        outputDir = objects.directoryProperty().convention(extension.outputDirectory)
     }
 
     /**

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
@@ -174,7 +174,6 @@ abstract class ConfiguredTask extends DefaultTask {
         settings.put(ANALYZER_NUSPEC_ENABLED, config.analyzers.nuspecEnabled.getOrNull())
         settings.put(ANALYZER_OSSINDEX_ENABLED, select(config.analyzers.ossIndex.enabled.getOrNull(), config.analyzers.ossIndexEnabled.getOrNull()))
         settings.put(ANALYZER_OSSINDEX_WARN_ONLY_ON_REMOTE_ERRORS, config.analyzers.ossIndex.warnOnlyOnRemoteErrors.getOrNull())
-        settings.put(ANALYZER_OSSINDEX_ENABLED, config.analyzers.ossIndex.enabled.getOrNull())
         settings.put(ANALYZER_OSSINDEX_USER, config.analyzers.ossIndex.username.getOrNull() ?: null)
         settings.put(ANALYZER_OSSINDEX_PASSWORD, config.analyzers.ossIndex.password.getOrNull() ?: null)
         settings.put(ANALYZER_OSSINDEX_URL, config.analyzers.ossIndex.url.getOrNull() ?: null)

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
@@ -19,9 +19,13 @@
 package org.owasp.dependencycheck.gradle.tasks
 
 import com.google.common.base.Strings
+import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
+import org.owasp.dependencycheck.gradle.extension.AnalyzeTaskConfig
 import org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension
 import org.owasp.dependencycheck.gradle.service.SlackNotificationSenderService
 import org.owasp.dependencycheck.utils.Downloader
@@ -37,18 +41,45 @@ import static org.owasp.dependencycheck.utils.Settings.KEYS.*
 @groovy.transform.CompileStatic
 abstract class ConfiguredTask extends DefaultTask {
 
+    @Nested
+    final AnalyzeTaskConfig config = project.objects.newInstance(AnalyzeTaskConfig)
     @Internal
-    DependencyCheckExtension config = (DependencyCheckExtension) project.getExtensions().findByName('dependencyCheck')
+    final DependencyCheckExtension extension = (DependencyCheckExtension) project.extensions.findByName('dependencyCheck')
     @Internal
     Settings settings
     @Internal
     String PROPERTIES_FILE = 'task.properties'
 
+    ConfiguredTask() {
+        config.skip.set(extension.skip)
+        config.analyzedTypes.set(extension.analyzedTypes)
+        config.failOnError.set(extension.failOnError)
+        config.format.set(extension.format)
+        config.formats.set(extension.formats)
+        config.scanBuildEnv.set(extension.scanBuildEnv)
+        config.scanDependencies.set(extension.scanDependencies)
+        config.scanConfigurations.set(extension.scanConfigurations)
+        config.skipConfigurations.set(extension.skipConfigurations)
+        config.scanProjects.set(extension.scanProjects)
+        config.skipProjects.set(extension.skipProjects)
+        config.showSummary.set(extension.showSummary)
+        config.failBuildOnCVSS.set(extension.failBuildOnCVSS)
+        config.skipGroups.set(extension.skipGroups)
+        config.skipTestGroups.set(extension.skipTestGroups)
+        config.scanSet.from(extension.scanSet)
+        config.additionalCpes.addAll(extension.additionalCpes)
+        config.settings.value(settingsMap(extension))
+    }
+
+    def config(Action<? super AnalyzeTaskConfig> action) {
+        action.execute(config)
+    }
+
     /**
      * Initializes the settings object. If the setting is not set the
      * default from dependency-check-core is used.
      */
-    protected void initializeSettings() {
+    void initializeSettings() {
         settings = new Settings()
 
         InputStream taskProperties = null
@@ -67,177 +98,203 @@ abstract class ConfiguredTask extends DefaultTask {
                 }
             }
         }
-        settings.setBooleanIfNotNull(AUTO_UPDATE, config.autoUpdate.getOrNull())
 
-        String[] suppressionLists = determineSuppressions(config.suppressionFiles.getOrElse([]), config.suppressionFile.getOrNull())
-
-        settings.setArrayIfNotEmpty(SUPPRESSION_FILE, suppressionLists)
-        settings.setStringIfNotEmpty(SUPPRESSION_FILE_USER, config.suppressionFileUser.getOrNull())
-        settings.setStringIfNotEmpty(SUPPRESSION_FILE_PASSWORD, config.suppressionFilePassword.getOrNull())
-        settings.setStringIfNotEmpty(SUPPRESSION_FILE_BEARER_TOKEN, config.suppressionFileBearerToken.getOrNull())
-        settings.setStringIfNotEmpty(HINTS_FILE, config.hintsFile.getOrNull())
-
-        configureProxy(settings)
-
-        configureSlack(settings)
-
-        //settings.setStringIfNotEmpty(CONNECTION_TIMEOUT, connectionTimeout)
-        settings.setStringIfNotNull(DATA_DIRECTORY, config.data.directory.getOrNull())
-        settings.setStringIfNotEmpty(DB_DRIVER_NAME, config.data.driver.getOrNull())
-        settings.setStringIfNotEmpty(DB_DRIVER_PATH, config.data.driverPath.getOrNull())
-        settings.setStringIfNotEmpty(DB_CONNECTION_STRING, config.data.connectionString.getOrNull())
-        settings.setStringIfNotEmpty(DB_USER, config.data.username.getOrNull())
-        settings.setStringIfNotEmpty(DB_PASSWORD, config.data.password.getOrNull())
-
-
-        settings.setStringIfNotEmpty(NVD_API_KEY, config.nvd.apiKey.getOrNull())
-        settings.setStringIfNotEmpty(NVD_API_ENDPOINT, config.nvd.endpoint.getOrNull())
-        settings.setIntIfNotNull(NVD_API_DELAY, config.nvd.delay.getOrNull())
-        settings.setIntIfNotNull(NVD_API_RESULTS_PER_PAGE, config.nvd.resultsPerPage.getOrNull())
-        settings.setIntIfNotNull(NVD_API_MAX_RETRY_COUNT, config.nvd.maxRetryCount.getOrNull())
-        settings.setIntIfNotNull(NVD_API_VALID_FOR_HOURS, config.nvd.validForHours.getOrNull());
-
-        settings.setStringIfNotEmpty(NVD_API_DATAFEED_URL, config.nvd.datafeedUrl.getOrNull())
-        if (config.nvd.datafeedUser.getOrNull() && config.nvd.datafeedPassword.getOrNull()) {
-            settings.setStringIfNotEmpty(NVD_API_DATAFEED_USER, config.nvd.datafeedUser.getOrNull())
-            settings.setStringIfNotEmpty(NVD_API_DATAFEED_PASSWORD, config.nvd.datafeedPassword.getOrNull())
-        }
-        settings.setStringIfNotEmpty(NVD_API_DATAFEED_BEARER_TOKEN, config.nvd.datafeedBearerToken.getOrNull())
-        settings.setIntIfNotNull(NVD_API_DATAFEED_START_YEAR, config.nvd.datafeedStartYear.getOrNull())
-
-        settings.setBooleanIfNotNull(DOWNLOADER_QUICK_QUERY_TIMESTAMP, config.quickQueryTimestamp.getOrNull())
-        settings.setFloat(JUNIT_FAIL_ON_CVSS, config.junitFailOnCVSS.get())
-        settings.setBooleanIfNotNull(FAIL_ON_UNUSED_SUPPRESSION_RULE, config.failBuildOnUnusedSuppressionRule.getOrNull())
-        settings.setBooleanIfNotNull(HOSTED_SUPPRESSIONS_ENABLED, config.hostedSuppressions.enabled.getOrNull())
-        settings.setBooleanIfNotNull(HOSTED_SUPPRESSIONS_FORCEUPDATE, config.hostedSuppressions.forceupdate.getOrNull())
-        settings.setStringIfNotNull(HOSTED_SUPPRESSIONS_URL, config.hostedSuppressions.url.getOrNull())
-        settings.setStringIfNotNull(HOSTED_SUPPRESSIONS_USER, config.hostedSuppressions.user.getOrNull())
-        settings.setStringIfNotNull(HOSTED_SUPPRESSIONS_PASSWORD, config.hostedSuppressions.password.getOrNull())
-        settings.setStringIfNotNull(HOSTED_SUPPRESSIONS_BEARER_TOKEN, config.hostedSuppressions.bearerToken.getOrNull())
-        if (config.hostedSuppressions.validForHours.getOrNull() != null) {
-            if (config.hostedSuppressions.validForHours.getOrNull() >= 0) {
-                settings.setInt(HOSTED_SUPPRESSIONS_VALID_FOR_HOURS, config.hostedSuppressions.validForHours.getOrNull())
-            } else {
-                throw new InvalidUserDataException('Invalid setting: `validForHours` must be 0 or greater')
+        for (def e : this.config.settings.get().entrySet()) {
+            switch (e.value) {
+            case Boolean:
+                settings.setBoolean(e.key, (Boolean) e.value)
+                break
+            case String:
+                settings.setString(e.key, (String) e.value)
+                break
+            case Float:
+            case Double:
+            case BigDecimal:
+                settings.setFloat(e.key, e.value as Float)
+                break
+            case Number:
+                settings.setInt(e.key, Math.toIntExact(e.value as Long))
+                break
+            case String[]:
+            case Collection:
+                settings.setArrayIfNotEmpty(e.key, e.value as String[])
+                break
+            default:
+                throw new IllegalArgumentException("Key $e.key has unsupported value type: $e.value")
             }
         }
-        settings.setBooleanIfNotNull(ANALYZER_JAR_ENABLED, config.analyzers.jarEnabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_NUSPEC_ENABLED, config.analyzers.nuspecEnabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_OSSINDEX_ENABLED, select(config.analyzers.ossIndex.enabled.getOrNull(), config.analyzers.ossIndexEnabled.getOrNull()))
-        settings.setBooleanIfNotNull(ANALYZER_OSSINDEX_WARN_ONLY_ON_REMOTE_ERRORS, config.analyzers.ossIndex.warnOnlyOnRemoteErrors.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_OSSINDEX_ENABLED, config.analyzers.ossIndex.enabled.getOrNull())
-        settings.setStringIfNotEmpty(ANALYZER_OSSINDEX_USER, config.analyzers.ossIndex.username.getOrNull())
-        settings.setStringIfNotEmpty(ANALYZER_OSSINDEX_PASSWORD, config.analyzers.ossIndex.password.getOrNull())
-        settings.setStringIfNotEmpty(ANALYZER_OSSINDEX_URL, config.analyzers.ossIndex.url.getOrNull())
-
-        settings.setBooleanIfNotNull(ANALYZER_CENTRAL_ENABLED, config.analyzers.centralEnabled.getOrNull())
-
-        settings.setBooleanIfNotNull(ANALYZER_NEXUS_ENABLED, config.analyzers.nexusEnabled.getOrNull())
-        settings.setStringIfNotEmpty(ANALYZER_NEXUS_URL, config.analyzers.nexusUrl.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_NEXUS_USES_PROXY, config.analyzers.nexusUsesProxy.getOrNull())
-
-        settings.setBooleanIfNotNull(ANALYZER_EXPERIMENTAL_ENABLED, config.analyzers.experimentalEnabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_ARCHIVE_ENABLED, config.analyzers.archiveEnabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_KNOWN_EXPLOITED_ENABLED, config.analyzers.kev.enabled.getOrNull())
-        settings.setStringIfNotNull(KEV_URL, config.analyzers.kev.url.getOrNull())
-        settings.setIntIfNotNull(KEV_CHECK_VALID_FOR_HOURS, config.analyzers.kev.validForHours.getOrNull())
-        settings.setStringIfNotNull(KEV_USER, config.analyzers.kev.user.getOrNull())
-        settings.setStringIfNotNull(KEV_PASSWORD, config.analyzers.kev.password.getOrNull())
-        settings.setStringIfNotNull(KEV_BEARER_TOKEN, config.analyzers.kev.bearerToken.getOrNull())
-        settings.setStringIfNotEmpty(ADDITIONAL_ZIP_EXTENSIONS, config.analyzers.zipExtensions.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_ASSEMBLY_ENABLED, config.analyzers.assemblyEnabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_MSBUILD_PROJECT_ENABLED, config.analyzers.msbuildEnabled.getOrNull())
-        settings.setStringIfNotEmpty(ANALYZER_ASSEMBLY_DOTNET_PATH, config.analyzers.pathToDotnet.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_GOLANG_DEP_ENABLED, config.analyzers.golangDepEnabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_GOLANG_MOD_ENABLED, config.analyzers.golangModEnabled.getOrNull())
-        settings.setStringIfNotNull(ANALYZER_GOLANG_PATH, config.analyzers.pathToGo.getOrNull())
-
-        settings.setBooleanIfNotNull(ANALYZER_COCOAPODS_ENABLED, config.analyzers.cocoapodsEnabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_SWIFT_PACKAGE_MANAGER_ENABLED, config.analyzers.swiftEnabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_DART_ENABLED, config.analyzers.dartEnabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_SWIFT_PACKAGE_RESOLVED_ENABLED, config.analyzers.swiftPackageResolvedEnabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_BUNDLE_AUDIT_ENABLED, config.analyzers.bundleAuditEnabled.getOrNull())
-        settings.setStringIfNotEmpty(ANALYZER_BUNDLE_AUDIT_PATH, config.analyzers.pathToBundleAudit.getOrNull())
-
-        settings.setBooleanIfNotNull(ANALYZER_PYTHON_DISTRIBUTION_ENABLED, config.analyzers.pyDistributionEnabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_PYTHON_PACKAGE_ENABLED, config.analyzers.pyPackageEnabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_RUBY_GEMSPEC_ENABLED, config.analyzers.rubygemsEnabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_OPENSSL_ENABLED, config.analyzers.opensslEnabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_CMAKE_ENABLED, config.analyzers.cmakeEnabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_AUTOCONF_ENABLED, config.analyzers.autoconfEnabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_COMPOSER_LOCK_ENABLED, config.analyzers.composerEnabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_COMPOSER_LOCK_SKIP_DEV, config.analyzers.composerSkipDev.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_CPANFILE_ENABLED, config.analyzers.cpanEnabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_NUGETCONF_ENABLED, config.analyzers.nugetconfEnabled.getOrNull())
-
-        settings.setBooleanIfNotNull(ANALYZER_NODE_PACKAGE_ENABLED, select(config.analyzers.nodePackage.enabled.getOrNull(), config.analyzers.nodeEnabled.getOrNull()))
-        settings.setBooleanIfNotNull(ANALYZER_NODE_PACKAGE_SKIPDEV, config.analyzers.nodePackage.skipDevDependencies.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_NODE_AUDIT_ENABLED, select(config.analyzers.nodeAudit.enabled.getOrNull(), config.analyzers.nodeAuditEnabled.getOrNull()))
-        settings.setBooleanIfNotNull(ANALYZER_NODE_AUDIT_USE_CACHE, config.analyzers.nodeAudit.useCache.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_NODE_AUDIT_SKIPDEV, config.analyzers.nodeAudit.skipDevDependencies.getOrNull())
-        settings.setStringIfNotEmpty(ANALYZER_NODE_AUDIT_URL, config.analyzers.nodeAudit.url.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_YARN_AUDIT_ENABLED, config.analyzers.nodeAudit.yarnEnabled.getOrNull())
-        settings.setStringIfNotNull(ANALYZER_YARN_PATH, config.analyzers.nodeAudit.yarnPath.getOrNull());
-        settings.setBooleanIfNotNull(ANALYZER_PNPM_AUDIT_ENABLED, config.analyzers.nodeAudit.pnpmEnabled.getOrNull())
-        settings.setStringIfNotNull(ANALYZER_PNPM_PATH, config.analyzers.nodeAudit.pnpmPath.getOrNull());
-        settings.setBooleanIfNotNull(ANALYZER_RETIREJS_ENABLED, config.analyzers.retirejs.enabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_RETIREJS_FORCEUPDATE, config.analyzers.retirejs.forceupdate.getOrNull())
-        settings.setStringIfNotNull(ANALYZER_RETIREJS_REPO_JS_URL, config.analyzers.retirejs.retireJsUrl.getOrNull())
-        settings.setStringIfNotNull(ANALYZER_RETIREJS_REPO_JS_USER, config.analyzers.retirejs.user.getOrNull())
-        settings.setStringIfNotNull(ANALYZER_RETIREJS_REPO_JS_PASSWORD, config.analyzers.retirejs.password.getOrNull())
-        settings.setStringIfNotNull(ANALYZER_RETIREJS_REPO_JS_BEARER_TOKEN, config.analyzers.retirejs.bearerToken.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_RETIREJS_FILTER_NON_VULNERABLE, config.analyzers.retirejs.filterNonVulnerable.getOrNull())
-        settings.setArrayIfNotEmpty(ANALYZER_RETIREJS_FILTERS, config.analyzers.retirejs.filters.getOrElse([]))
-
-        settings.setBooleanIfNotNull(ANALYZER_ARTIFACTORY_ENABLED, config.analyzers.artifactory.enabled.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_ARTIFACTORY_PARALLEL_ANALYSIS, config.analyzers.artifactory.parallelAnalysis.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_ARTIFACTORY_USES_PROXY, config.analyzers.artifactory.usesProxy.getOrNull())
-        settings.setStringIfNotNull(ANALYZER_ARTIFACTORY_URL, config.analyzers.artifactory.url.getOrNull())
-        settings.setStringIfNotNull(ANALYZER_ARTIFACTORY_API_TOKEN, config.analyzers.artifactory.apiToken.getOrNull())
-        settings.setStringIfNotNull(ANALYZER_ARTIFACTORY_API_USERNAME, config.analyzers.artifactory.username.getOrNull())
-        settings.setStringIfNotNull(ANALYZER_ARTIFACTORY_BEARER_TOKEN, config.analyzers.artifactory.bearerToken.getOrNull())
-
-        settings.setBooleanIfNotNull(ANALYZER_NODE_AUDIT_USE_CACHE, config.cache.nodeAudit.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_CENTRAL_USE_CACHE, config.cache.central.getOrNull())
-        settings.setBooleanIfNotNull(ANALYZER_OSSINDEX_USE_CACHE, config.cache.ossIndex.getOrNull())
 
         Downloader.getInstance().configure(settings);
     }
 
-    private void configureSlack(Settings settings) {
-        settings.setBooleanIfNotNull(SlackNotificationSenderService.SLACK__WEBHOOK__ENABLED, config.slack.enabled.getOrNull())
-        settings.setStringIfNotEmpty(SlackNotificationSenderService.SLACK__WEBHOOK__URL, config.slack.webhookUrl.getOrNull())
-    }
+    private Map<String, Object> settingsMap(DependencyCheckExtension config) {
+        Map<String, Object> settings = [:]
 
-    private void configureProxy(Settings settings) {
-        String proxyHost = System.getProperty("https.proxyHost", System.getProperty("http.proxyHost"))
-        if (!Strings.isNullOrEmpty(proxyHost)) {
-            String proxyPort = System.getProperty("https.proxyPort", System.getProperty("http.proxyPort"))
-            String nonProxyHosts = System.getProperty("https.nonProxyHosts", System.getProperty("http.nonProxyHosts"))
-            String proxyUser = System.getProperty("https.proxyUser", System.getProperty("http.proxyUser"))
-            String proxyPassword = System.getProperty("https.proxyPassword", System.getProperty("http.proxyPassword"))
-            config.proxy.server.set(proxyHost)
-            try {
-                config.proxy.port.set(Integer.parseInt(proxyPort))
-            } catch (NumberFormatException nfe) {
-                logger.warn("Unable to convert the configured `http.proxyPort` to a number: ${proxyPort}");
-            }
-            if (!Strings.isNullOrEmpty(proxyUser)) {
-                config.proxy.username.set(proxyUser)
-            }
-            if (!Strings.isNullOrEmpty(proxyPassword)) {
-                config.proxy.password.set(proxyPassword)
-            }
-            if (!Strings.isNullOrEmpty(nonProxyHosts)) {
-                config.proxy.nonProxyHosts.set(nonProxyHosts.tokenize("|"))
+        settings.put(AUTO_UPDATE, config.autoUpdate.getOrNull())
+
+        String[] suppressionLists = determineSuppressions(config.suppressionFiles.getOrElse([]), config.suppressionFile.getOrNull())
+
+        settings.put(SUPPRESSION_FILE, suppressionLists)
+        settings.put(SUPPRESSION_FILE_USER, config.suppressionFileUser.getOrNull() ?: null)
+        settings.put(SUPPRESSION_FILE_PASSWORD, config.suppressionFilePassword.getOrNull() ?: null)
+        settings.put(SUPPRESSION_FILE_BEARER_TOKEN, config.suppressionFileBearerToken.getOrNull() ?: null)
+        settings.put(HINTS_FILE, config.hintsFile.getOrNull() ?: null)
+
+        configureProxy(settings, config)
+
+        configureSlack(settings, config)
+
+        //settings.put(CONNECTION_TIMEOUT, connectionTimeout)
+        settings.put(DATA_DIRECTORY, config.data.directory.getOrNull())
+        settings.put(DB_DRIVER_NAME, config.data.driver.getOrNull() ?: null)
+        settings.put(DB_DRIVER_PATH, config.data.driverPath.getOrNull() ?: null)
+        settings.put(DB_CONNECTION_STRING, config.data.connectionString.getOrNull() ?: null)
+        settings.put(DB_USER, config.data.username.getOrNull() ?: null)
+        settings.put(DB_PASSWORD, config.data.password.getOrNull() ?: null)
+
+
+        settings.put(NVD_API_KEY, config.nvd.apiKey.getOrNull() ?: null)
+        settings.put(NVD_API_ENDPOINT, config.nvd.endpoint.getOrNull() ?: null)
+        settings.put(NVD_API_DELAY, config.nvd.delay.getOrNull())
+        settings.put(NVD_API_RESULTS_PER_PAGE, config.nvd.resultsPerPage.getOrNull())
+        settings.put(NVD_API_MAX_RETRY_COUNT, config.nvd.maxRetryCount.getOrNull())
+        settings.put(NVD_API_VALID_FOR_HOURS, config.nvd.validForHours.getOrNull());
+
+        settings.put(NVD_API_DATAFEED_URL, config.nvd.datafeedUrl.getOrNull() ?: null)
+        if (config.nvd.datafeedUser.getOrNull() && config.nvd.datafeedPassword.getOrNull()) {
+            settings.put(NVD_API_DATAFEED_USER, config.nvd.datafeedUser.getOrNull() ?: null)
+            settings.put(NVD_API_DATAFEED_PASSWORD, config.nvd.datafeedPassword.getOrNull() ?: null)
+        }
+        settings.put(NVD_API_DATAFEED_BEARER_TOKEN, config.nvd.datafeedBearerToken.getOrNull() ?: null)
+        settings.put(NVD_API_DATAFEED_START_YEAR, config.nvd.datafeedStartYear.getOrNull())
+
+        settings.put(DOWNLOADER_QUICK_QUERY_TIMESTAMP, config.quickQueryTimestamp.getOrNull())
+        settings.put(JUNIT_FAIL_ON_CVSS, config.junitFailOnCVSS.get())
+        settings.put(FAIL_ON_UNUSED_SUPPRESSION_RULE, config.failBuildOnUnusedSuppressionRule.getOrNull())
+        settings.put(HOSTED_SUPPRESSIONS_ENABLED, config.hostedSuppressions.enabled.getOrNull())
+        settings.put(HOSTED_SUPPRESSIONS_FORCEUPDATE, config.hostedSuppressions.forceupdate.getOrNull())
+        settings.put(HOSTED_SUPPRESSIONS_URL, config.hostedSuppressions.url.getOrNull())
+        settings.put(HOSTED_SUPPRESSIONS_USER, config.hostedSuppressions.user.getOrNull())
+        settings.put(HOSTED_SUPPRESSIONS_PASSWORD, config.hostedSuppressions.password.getOrNull())
+        settings.put(HOSTED_SUPPRESSIONS_BEARER_TOKEN, config.hostedSuppressions.bearerToken.getOrNull())
+        if (config.hostedSuppressions.validForHours.getOrNull() != null) {
+            if (config.hostedSuppressions.validForHours.getOrNull() >= 0) {
+                settings.put(HOSTED_SUPPRESSIONS_VALID_FOR_HOURS, config.hostedSuppressions.validForHours.getOrNull())
+            } else {
+                throw new InvalidUserDataException('Invalid setting: `validForHours` must be 0 or greater')
             }
         }
-        settings.setStringIfNotEmpty(PROXY_SERVER, config.proxy.server.getOrNull())
-        settings.setStringIfNotEmpty(PROXY_PORT, config.proxy.port.getOrNull()?.toString())
-        settings.setStringIfNotEmpty(PROXY_USERNAME, config.proxy.username.getOrNull())
-        settings.setStringIfNotEmpty(PROXY_PASSWORD, config.proxy.password.getOrNull())
-        def nonProxyHostsList = config.proxy.nonProxyHosts.getOrElse([])
-        settings.setStringIfNotEmpty(PROXY_NON_PROXY_HOSTS, nonProxyHostsList ? nonProxyHostsList.join("|") : null)
+        settings.put(ANALYZER_JAR_ENABLED, config.analyzers.jarEnabled.getOrNull())
+        settings.put(ANALYZER_NUSPEC_ENABLED, config.analyzers.nuspecEnabled.getOrNull())
+        settings.put(ANALYZER_OSSINDEX_ENABLED, select(config.analyzers.ossIndex.enabled.getOrNull(), config.analyzers.ossIndexEnabled.getOrNull()))
+        settings.put(ANALYZER_OSSINDEX_WARN_ONLY_ON_REMOTE_ERRORS, config.analyzers.ossIndex.warnOnlyOnRemoteErrors.getOrNull())
+        settings.put(ANALYZER_OSSINDEX_ENABLED, config.analyzers.ossIndex.enabled.getOrNull())
+        settings.put(ANALYZER_OSSINDEX_USER, config.analyzers.ossIndex.username.getOrNull() ?: null)
+        settings.put(ANALYZER_OSSINDEX_PASSWORD, config.analyzers.ossIndex.password.getOrNull() ?: null)
+        settings.put(ANALYZER_OSSINDEX_URL, config.analyzers.ossIndex.url.getOrNull() ?: null)
+
+        settings.put(ANALYZER_CENTRAL_ENABLED, config.analyzers.centralEnabled.getOrNull())
+
+        settings.put(ANALYZER_NEXUS_ENABLED, config.analyzers.nexusEnabled.getOrNull())
+        settings.put(ANALYZER_NEXUS_URL, config.analyzers.nexusUrl.getOrNull() ?: null)
+        settings.put(ANALYZER_NEXUS_USES_PROXY, config.analyzers.nexusUsesProxy.getOrNull())
+
+        settings.put(ANALYZER_EXPERIMENTAL_ENABLED, config.analyzers.experimentalEnabled.getOrNull())
+        settings.put(ANALYZER_ARCHIVE_ENABLED, config.analyzers.archiveEnabled.getOrNull())
+        settings.put(ANALYZER_KNOWN_EXPLOITED_ENABLED, config.analyzers.kev.enabled.getOrNull())
+        settings.put(KEV_URL, config.analyzers.kev.url.getOrNull())
+        settings.put(KEV_CHECK_VALID_FOR_HOURS, config.analyzers.kev.validForHours.getOrNull())
+        settings.put(KEV_USER, config.analyzers.kev.user.getOrNull())
+        settings.put(KEV_PASSWORD, config.analyzers.kev.password.getOrNull())
+        settings.put(KEV_BEARER_TOKEN, config.analyzers.kev.bearerToken.getOrNull())
+        settings.put(ADDITIONAL_ZIP_EXTENSIONS, config.analyzers.zipExtensions.getOrNull() ?: null)
+        settings.put(ANALYZER_ASSEMBLY_ENABLED, config.analyzers.assemblyEnabled.getOrNull())
+        settings.put(ANALYZER_MSBUILD_PROJECT_ENABLED, config.analyzers.msbuildEnabled.getOrNull())
+        settings.put(ANALYZER_ASSEMBLY_DOTNET_PATH, config.analyzers.pathToDotnet.getOrNull() ?: null)
+        settings.put(ANALYZER_GOLANG_DEP_ENABLED, config.analyzers.golangDepEnabled.getOrNull())
+        settings.put(ANALYZER_GOLANG_MOD_ENABLED, config.analyzers.golangModEnabled.getOrNull())
+        settings.put(ANALYZER_GOLANG_PATH, config.analyzers.pathToGo.getOrNull())
+
+        settings.put(ANALYZER_COCOAPODS_ENABLED, config.analyzers.cocoapodsEnabled.getOrNull())
+        settings.put(ANALYZER_SWIFT_PACKAGE_MANAGER_ENABLED, config.analyzers.swiftEnabled.getOrNull())
+        settings.put(ANALYZER_DART_ENABLED, config.analyzers.dartEnabled.getOrNull())
+        settings.put(ANALYZER_SWIFT_PACKAGE_RESOLVED_ENABLED, config.analyzers.swiftPackageResolvedEnabled.getOrNull())
+        settings.put(ANALYZER_BUNDLE_AUDIT_ENABLED, config.analyzers.bundleAuditEnabled.getOrNull())
+        settings.put(ANALYZER_BUNDLE_AUDIT_PATH, config.analyzers.pathToBundleAudit.getOrNull() ?: null)
+
+        settings.put(ANALYZER_PYTHON_DISTRIBUTION_ENABLED, config.analyzers.pyDistributionEnabled.getOrNull())
+        settings.put(ANALYZER_PYTHON_PACKAGE_ENABLED, config.analyzers.pyPackageEnabled.getOrNull())
+        settings.put(ANALYZER_RUBY_GEMSPEC_ENABLED, config.analyzers.rubygemsEnabled.getOrNull())
+        settings.put(ANALYZER_OPENSSL_ENABLED, config.analyzers.opensslEnabled.getOrNull())
+        settings.put(ANALYZER_CMAKE_ENABLED, config.analyzers.cmakeEnabled.getOrNull())
+        settings.put(ANALYZER_AUTOCONF_ENABLED, config.analyzers.autoconfEnabled.getOrNull())
+        settings.put(ANALYZER_COMPOSER_LOCK_ENABLED, config.analyzers.composerEnabled.getOrNull())
+        settings.put(ANALYZER_COMPOSER_LOCK_SKIP_DEV, config.analyzers.composerSkipDev.getOrNull())
+        settings.put(ANALYZER_CPANFILE_ENABLED, config.analyzers.cpanEnabled.getOrNull())
+        settings.put(ANALYZER_NUGETCONF_ENABLED, config.analyzers.nugetconfEnabled.getOrNull())
+
+        settings.put(ANALYZER_NODE_PACKAGE_ENABLED, select(config.analyzers.nodePackage.enabled.getOrNull(), config.analyzers.nodeEnabled.getOrNull()))
+        settings.put(ANALYZER_NODE_PACKAGE_SKIPDEV, config.analyzers.nodePackage.skipDevDependencies.getOrNull())
+        settings.put(ANALYZER_NODE_AUDIT_ENABLED, select(config.analyzers.nodeAudit.enabled.getOrNull(), config.analyzers.nodeAuditEnabled.getOrNull()))
+        settings.put(ANALYZER_NODE_AUDIT_USE_CACHE, config.analyzers.nodeAudit.useCache.getOrNull())
+        settings.put(ANALYZER_NODE_AUDIT_SKIPDEV, config.analyzers.nodeAudit.skipDevDependencies.getOrNull())
+        settings.put(ANALYZER_NODE_AUDIT_URL, config.analyzers.nodeAudit.url.getOrNull() ?: null)
+        settings.put(ANALYZER_YARN_AUDIT_ENABLED, config.analyzers.nodeAudit.yarnEnabled.getOrNull())
+        settings.put(ANALYZER_YARN_PATH, config.analyzers.nodeAudit.yarnPath.getOrNull());
+        settings.put(ANALYZER_PNPM_AUDIT_ENABLED, config.analyzers.nodeAudit.pnpmEnabled.getOrNull())
+        settings.put(ANALYZER_PNPM_PATH, config.analyzers.nodeAudit.pnpmPath.getOrNull());
+        settings.put(ANALYZER_RETIREJS_ENABLED, config.analyzers.retirejs.enabled.getOrNull())
+        settings.put(ANALYZER_RETIREJS_FORCEUPDATE, config.analyzers.retirejs.forceupdate.getOrNull())
+        settings.put(ANALYZER_RETIREJS_REPO_JS_URL, config.analyzers.retirejs.retireJsUrl.getOrNull())
+        settings.put(ANALYZER_RETIREJS_REPO_JS_USER, config.analyzers.retirejs.user.getOrNull())
+        settings.put(ANALYZER_RETIREJS_REPO_JS_PASSWORD, config.analyzers.retirejs.password.getOrNull())
+        settings.put(ANALYZER_RETIREJS_REPO_JS_BEARER_TOKEN, config.analyzers.retirejs.bearerToken.getOrNull())
+        settings.put(ANALYZER_RETIREJS_FILTER_NON_VULNERABLE, config.analyzers.retirejs.filterNonVulnerable.getOrNull())
+        settings.put(ANALYZER_RETIREJS_FILTERS, config.analyzers.retirejs.filters.getOrElse([]))
+
+        settings.put(ANALYZER_ARTIFACTORY_ENABLED, config.analyzers.artifactory.enabled.getOrNull())
+        settings.put(ANALYZER_ARTIFACTORY_PARALLEL_ANALYSIS, config.analyzers.artifactory.parallelAnalysis.getOrNull())
+        settings.put(ANALYZER_ARTIFACTORY_USES_PROXY, config.analyzers.artifactory.usesProxy.getOrNull())
+        settings.put(ANALYZER_ARTIFACTORY_URL, config.analyzers.artifactory.url.getOrNull())
+        settings.put(ANALYZER_ARTIFACTORY_API_TOKEN, config.analyzers.artifactory.apiToken.getOrNull())
+        settings.put(ANALYZER_ARTIFACTORY_API_USERNAME, config.analyzers.artifactory.username.getOrNull())
+        settings.put(ANALYZER_ARTIFACTORY_BEARER_TOKEN, config.analyzers.artifactory.bearerToken.getOrNull())
+
+        settings.put(ANALYZER_NODE_AUDIT_USE_CACHE, config.cache.nodeAudit.getOrNull())
+        settings.put(ANALYZER_CENTRAL_USE_CACHE, config.cache.central.getOrNull())
+        settings.put(ANALYZER_OSSINDEX_USE_CACHE, config.cache.ossIndex.getOrNull())
+
+        settings.removeAll { it.value == null }
+        settings
+    }
+
+    private void configureSlack(Map<String, Object> settings, DependencyCheckExtension config) {
+        settings.put(SlackNotificationSenderService.SLACK__WEBHOOK__ENABLED, config.slack.enabled.getOrNull())
+        settings.put(SlackNotificationSenderService.SLACK__WEBHOOK__URL, config.slack.webhookUrl.getOrNull() ?: null)
+    }
+
+    private void configureProxy(Map<String, Object> settings, DependencyCheckExtension config) {
+        String proxyHost = System.getProperty("https.proxyHost", System.getProperty("http.proxyHost"))
+        String proxyPort = System.getProperty("https.proxyPort", System.getProperty("http.proxyPort"))
+        String nonProxyHosts = System.getProperty("https.nonProxyHosts", System.getProperty("http.nonProxyHosts"))
+        String proxyUser = System.getProperty("https.proxyUser", System.getProperty("http.proxyUser"))
+        String proxyPassword = System.getProperty("https.proxyPassword", System.getProperty("http.proxyPassword"))
+
+        if (proxyPort) {
+            try {
+                proxyPort = Integer.parseInt(proxyPort).toString()
+            } catch (NumberFormatException nfe) {
+                logger.warn("Unable to convert the configured `http.proxyPort` to a number: ${proxyPort}");
+                proxyPort = null
+            }
+        }
+
+        settings.put(PROXY_SERVER, proxyHost ?: config.proxy.server.getOrNull() ?: null)
+        settings.put(PROXY_PORT, proxyPort ?: config.proxy.port.getOrNull()?.toString())
+        settings.put(PROXY_USERNAME, proxyUser ?: config.proxy.username.getOrNull() ?: null)
+        settings.put(PROXY_PASSWORD, proxyPassword ?: config.proxy.password.getOrNull() ?: null)
+        def nonProxyHostsList = nonProxyHosts ? nonProxyHosts.tokenize("|") : config.proxy.nonProxyHosts.getOrElse([])
+        settings.put(PROXY_NON_PROXY_HOSTS, nonProxyHostsList ? nonProxyHostsList.join("|") : null)
     }
 
     /**

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Purge.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Purge.groovy
@@ -19,8 +19,10 @@
 package org.owasp.dependencycheck.gradle.tasks
 
 
+import org.gradle.api.Action
 import org.gradle.api.tasks.TaskAction
 import org.owasp.dependencycheck.Engine
+import org.owasp.dependencycheck.gradle.extension.DependencyCheckTaskConfig
 
 /**
  * Purges the local cache of the NVD CVE data.
@@ -34,6 +36,10 @@ class Purge extends ConfiguredTask {
     Purge() {
         group = 'OWASP dependency-check'
         description = 'Purges the local cache of the NVD.'
+    }
+
+    def config(Action<? super DependencyCheckTaskConfig> action) {
+        action.execute(config)
     }
 
     /**

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Update.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Update.groovy
@@ -19,11 +19,13 @@
 package org.owasp.dependencycheck.gradle.tasks
 
 
+import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
 import org.owasp.dependencycheck.Engine
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException
 import org.owasp.dependencycheck.data.update.exception.UpdateException
+import org.owasp.dependencycheck.gradle.extension.DependencyCheckTaskConfig
 
 import static org.owasp.dependencycheck.utils.Settings.KEYS.AUTO_UPDATE
 
@@ -41,6 +43,10 @@ class Update extends ConfiguredTask {
     Update() {
         group = 'OWASP dependency-check'
         description = 'Downloads and stores updates from the NVD CVE data feeds.'
+    }
+
+    def config(Action<? super DependencyCheckTaskConfig> action) {
+        action.execute(config)
     }
 
     /**

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
@@ -223,7 +223,6 @@ class DependencyCheckGradlePluginSpec extends Specification {
 
     def 'NexusExtension properties configure task settings'() {
         given:
-        def task = project.tasks.findByName(taskName)
         with(project.dependencyCheck.analyzers.nexus) {
             enabled.set(true)
             usesProxy.set(true)
@@ -231,6 +230,7 @@ class DependencyCheckGradlePluginSpec extends Specification {
             username.set('user')
             password.set('pass')
         }
+        def task = project.tasks.findByName(taskName)
 
         when:
         task.initializeSettings()

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPluginIntegSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPluginIntegSpec.groovy
@@ -137,20 +137,20 @@ class DependencyCheckPluginIntegSpec extends Specification {
 
                     tasks.named('dependencyCheckAnalyze') {
                         config {
-                            failBuildOnCVSS = 4.5f
+                            failBuildOnCVSS = 4.5
                             settings.put('junit.fail.on.cvss', 5.5)
                         }
                         doLast {
-                            assert config.failBuildOnCVSS.get() == 4.5f
-                            assert settings.getFloat('junit.fail.on.cvss', 0) == 5.5f
+                            assert config.failBuildOnCVSS.get() == 4.5
+                            assert settings.getFloat('junit.fail.on.cvss', 0) == 5.5
                             assert settings.getString('nvd.api.datafeed.url') == 'https://dependency-check.github.io/DependencyCheck/hb_nvd/'
                         }
                     }
 
                     tasks.register('testAnalyze', org.owasp.dependencycheck.gradle.tasks.Analyze) {
                         doLast {
-                            assert config.failBuildOnCVSS.get() == 2.5f
-                            assert settings.getFloat('junit.fail.on.cvss', 0) == 3.5f
+                            assert config.failBuildOnCVSS.get() == 2.5
+                            assert settings.getFloat('junit.fail.on.cvss', 0) == 3.5
                             assert settings.getString('nvd.api.datafeed.url') == 'https://dependency-check.github.io/DependencyCheck/hb_nvd/'
                         }
                     }

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPluginIntegSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPluginIntegSpec.groovy
@@ -119,7 +119,7 @@ class DependencyCheckPluginIntegSpec extends Specification {
         result.task(":$DependencyCheckPlugin.ANALYZE_TASK").outcome == SUCCESS
     }
 
-    def "mulitple Analyze task configured"() {
+    def "multiple Analyze task configured"() {
         given:
         fileSystemFixture.create {
             dir("tasks") {


### PR DESCRIPTION
This PR exposes low-level `Settings` configuration for tasks.
The main purpose is to have ability to configure `Settings` keys that are not available through `DependencyCheckExtension` e.g. see #489 or to set up new version of dependency-check-core with old plugin version where extension DSL is not yet upgraded for new features.

`DependencyCheckTaskConfig`/`AnalyzeTaskConfig` input hierarchy was introduced to configure tasks and this should resolve #484 issue. `DependencyCheckExtension` provides conventions for task inputs that can be refined for specific task:

```kotlin
tasks.register<Analyze>("ossCheck") {
	config {
		settings.put(Settings.KEYS.ANALYZER_OSSINDEX_ENABLED, true)
	}
}
```

Most of the changes are in `ConfiguredTask`.
`Settings` values collected from `DependencyCheckExtension` to `MapProperty` of `DependencyCheckTaskConfig`.
Groovy truth is used to replicate `setStringIfNotEmpty` cases coercing empty strings to `null`:
```groovy
getOrNull() ?: null
```
then nulls removed:
```groovy
settings.removeAll { it.value == null }
```
The only thing I worry about is `AnalyzeTaskConfig.isScanSetConfigured` flag.
I simplified it to `!scanSet.empty` so it may break expectations regarding setting `scanSet` to empty list.

Lastly I think it's worth mentioning that Analyze task inputs involved in gradle up-to-date checks which may make sense in some cases, however dependencyCheck result generally depends on external oss/nvd state so it is good to mention [disable up-to-date checks](https://docs.gradle.org/current/userguide/incremental_build.html#sec:disable-state-tracking) option.

cc @ThomGeG