### PR TITLE
fix: address 12.2.1 regression during interop with plugins dynamically adding configs

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -451,7 +451,7 @@ abstract class AbstractAnalyze extends ConfiguredTask {
      * @param engine the dependency-check engine
      */
     protected void processBuildEnvironment(Project project, Engine engine) {
-        project.getBuildscript().configurations.matching(this.&shouldProcess).each { Configuration configuration ->
+        project.getBuildscript().configurations.matching(this.&shouldProcess).toList().each { Configuration configuration ->
             processConfig project, configuration, engine, true
         }
     }
@@ -462,7 +462,7 @@ abstract class AbstractAnalyze extends ConfiguredTask {
      * @param engine the dependency-check engine
      */
     protected void processConfigurations(Project project, Engine engine) {
-        project.configurations.matching(this.&shouldProcess).each { Configuration configuration ->
+        project.configurations.matching(this.&shouldProcess).toList().each { Configuration configuration ->
             processConfig project, configuration, engine, false
         }
         if (!config.isScanSetConfigured()) {

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPluginIntegSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPluginIntegSpec.groovy
@@ -1,6 +1,7 @@
 package org.owasp.dependencycheck.gradle
 
 import org.gradle.testkit.runner.GradleRunner
+import spock.lang.IgnoreIf
 import spock.lang.Specification
 import spock.lang.TempDir
 import spock.util.io.FileSystemFixture
@@ -121,5 +122,41 @@ class DependencyCheckPluginIntegSpec extends Specification {
 
         where:
         gradle << GradleTestVersion.supportedVersionsForCurrentJvm
+    }
+
+    @IgnoreIf(value = { !jvm.isJavaVersionCompatible(17) }, reason = "Quarkus under test requires Java 17")
+    def "task completes successfully when analyzing quarkus configurations"() {
+        given:
+        fileSystemFixture.create {
+            file("build.gradle").text = """
+                plugins {
+                    id 'org.owasp.dependencycheck'
+                    id 'io.quarkus' version '3.34.5'
+                }
+
+                version = '1.0'
+
+                dependencyCheck {
+                    analyzers.ossIndex.enabled = false
+                    nvd.datafeedUrl = 'https://dependency-check.github.io/DependencyCheck/hb_nvd/'
+                }
+            """.stripIndent()
+        }
+
+        when:
+        def result = GradleRunner.create()
+                .withGradleVersion(gradle.version)
+                .withProjectDir(fileSystemFixture.dir("").toFile())
+                .withArguments(DependencyCheckPlugin.ANALYZE_TASK, '--stacktrace')
+                .withPluginClasspath()
+                .withDebug(true)
+                .forwardOutput()
+                .build()
+
+        then:
+        result.task(":$DependencyCheckPlugin.ANALYZE_TASK").outcome == SUCCESS
+
+        where:
+        gradle << GradleTestVersion.supportedVersionsForCurrentJvmFrom(8) // Quarkus plugin under test needs Gradle 8
     }
 }


### PR DESCRIPTION
- fixes #500 

The Quarkus Gradle plugin up to at least `3.34.5` dynamically creates configurations during resolution of different configurations in ways that are technically breaches of the Gradle API contract, since they mutate collections during matching.

This was working in ODC <= `12.2.0` because we used a deprecated Gradle API (`.findAll`) method to eagerly resolve configurations, so this reverts to that behaviour using non-deprecated API.

This fails in `12.2.1` with ConcurrentModificationException because I changed it to use Gradle's recommended lazy iterators. These are not consistent during iteration and fail when Quarkus adds new configurations while we are iterating and resolving them. Gradle team told Quarkus not to use this unsafe mechanism, but Quarkus team said they were not suggested any alternative mechanism.

```
Resolving configuration quarkusConditionalDevRuntimeClasspath had effect of dynamically adding: [quarkusDevBaseRuntimeClasspathConfigurationCopy1]
Resolving configuration quarkusConditionalProdRuntimeClasspath had effect of dynamically adding: [quarkusProdBaseRuntimeClasspathConfigurationCopy1]
Resolving configuration quarkusConditionalTestRuntimeClasspath had effect of dynamically adding: [quarkusTestBaseRuntimeClasspathConfigurationCopy1]
```

This is a short-term workaround to store the configuration list before iterating, similar to the plugin at 12.2.1, alongside a regression test that fails. The assumption is that these additional configurations are not important to scan for ODC, as they seem to just be copies of others temporarily used for determining the contents of the “main” configurations.

A better fix on ODC side will probably involve fixes to the build caching which will also likely require defining dependencies on specific configurations correctly, and determining the target dependency set which will involve resolving configurations earlier anyway. A "proper" fix can probably only be done within Quarkus, potentially as an adjacent issue to https://github.com/quarkusio/quarkus/issues/50418