### PR TITLE
chore: remove setting of unused/deprecated quickQueryTimestamp setting

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
@@ -51,7 +51,6 @@ class DependencyCheckExtension {
     private final Property<Boolean> scanBuildEnv
     private final Property<Boolean> scanDependencies
     private final Property<Boolean> failOnError
-    private final Property<Boolean> quickQueryTimestamp
     private final DirectoryProperty outputDirectory
     private final Property<String> suppressionFile
     private final ListProperty<String> suppressionFiles
@@ -124,7 +123,6 @@ class DependencyCheckExtension {
         this.scanBuildEnv = objects.property(Boolean).convention(false)
         this.scanDependencies = objects.property(Boolean).convention(true)
         this.failOnError = objects.property(Boolean).convention(true)
-        this.quickQueryTimestamp = objects.property(Boolean)
         this.outputDirectory = objects.directoryProperty().convention(project.layout.buildDirectory.dir("reports"))
         this.suppressionFile = objects.property(String)
         this.suppressionFiles = objects.listProperty(String).convention([])
@@ -196,19 +194,6 @@ class DependencyCheckExtension {
 
     void setFailOnError(Boolean value) {
         failOnError.set(value)
-    }
-
-    /**
-     * Set to false if the proxy does not support HEAD requests. The default is true.
-     */
-    @Input
-    @Optional
-    Property<Boolean> getQuickQueryTimestamp() {
-        return quickQueryTimestamp
-    }
-
-    void setQuickQueryTimestamp(Boolean value) {
-        quickQueryTimestamp.set(value)
     }
 
     /**

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
@@ -106,7 +106,6 @@ abstract class ConfiguredTask extends DefaultTask {
         settings.setStringIfNotEmpty(NVD_API_DATAFEED_BEARER_TOKEN, config.nvd.datafeedBearerToken.getOrNull())
         settings.setIntIfNotNull(NVD_API_DATAFEED_START_YEAR, config.nvd.datafeedStartYear.getOrNull())
 
-        settings.setBooleanIfNotNull(DOWNLOADER_QUICK_QUERY_TIMESTAMP, config.quickQueryTimestamp.getOrNull())
         settings.setFloat(JUNIT_FAIL_ON_CVSS, config.junitFailOnCVSS.get())
         settings.setBooleanIfNotNull(FAIL_ON_UNUSED_SUPPRESSION_RULE, config.failBuildOnUnusedSuppressionRule.getOrNull())
         settings.setBooleanIfNotNull(HOSTED_SUPPRESSIONS_ENABLED, config.hostedSuppressions.enabled.getOrNull())

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
@@ -84,7 +84,6 @@ class DependencyCheckGradlePluginSpec extends Specification {
         project.dependencyCheck.nvd.delay.getOrNull() == null
         project.dependencyCheck.nvd.maxRetryCount.getOrNull() == null
         project.dependencyCheck.outputDirectory.get().asFile == project.file("${project.buildDir}/reports")
-        project.dependencyCheck.quickQueryTimestamp.getOrNull() == null
         project.dependencyCheck.scanConfigurations.get() == []
         project.dependencyCheck.skipConfigurations.get() == []
         project.dependencyCheck.scanProjects.get() == []
@@ -126,7 +125,6 @@ class DependencyCheckGradlePluginSpec extends Specification {
             analyzers.retirejs.filterNonVulnerable = true
 
             outputDirectory = 'outputDirectory'
-            quickQueryTimestamp = false
 
             scanConfigurations = ['a']
             skipConfigurations = ['b']
@@ -172,7 +170,6 @@ class DependencyCheckGradlePluginSpec extends Specification {
         project.dependencyCheck.hostedSuppressions.validForHours.get() == 5
         project.dependencyCheck.hostedSuppressions.forceupdate.get() == true
         project.dependencyCheck.outputDirectory.get().asFile == project.file('outputDirectory')
-        project.dependencyCheck.quickQueryTimestamp.get() == false
         project.dependencyCheck.scanConfigurations.get() == ['a']
         project.dependencyCheck.skipConfigurations.get() == ['b']
         project.dependencyCheck.scanProjects.get() == ['a']


### PR DESCRIPTION
This setting was removed some time ago in ODC and does nothing now. It has never been documented within the Gradle plugin since its introduction in 2015, so it's probably unused and minimal risk of breaking folks?

If we _really_ don't want to break the property API in any way, I can remove calling the deprecated method in ODC and deprecate the property in the DSL here.