### PR TITLE
feat: allow configuration of Sonatype Guide / OSS Index cache validity time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      - dependency-name: "gradle-wrapper" # Don't update the gradle wrapper major version, as impacts plugin API compatibility
-        update-types: ["version-update:semver-major"]
+      - dependency-name: "gradle-wrapper"             # Don't try and update the Gradle wrapper major version,
+        update-types: ["version-update:semver-major"] # as it changes plugin API compatibility.
+      - dependency-name: "org.junit:junit-bom"        # Don't try and update JUnit major version,
+        update-types: ["version-update:semver-major"] # as it changes Java version compatibility.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 odc = '12.2.1'
 spock = '2.4-groovy-3.0'
-junit = '5.14.3'
+junit = '5.14.4'
 
 [libraries]
 owasp-dependencyCheck-core = { module = 'org.owasp:dependency-check-core', version.ref = 'odc' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-odc = '12.2.1'
+odc = '12.2.2-SNAPSHOT'
 spock = '2.4-groovy-3.0'
 junit = '5.14.4'
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,8 +25,15 @@ pluginManagement {
 
 dependencyResolutionManagement {
     repositories {
-        mavenLocal()
         mavenCentral()
+        maven {
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+            mavenContent {
+                snapshotsOnly()
+                includeGroup("org.owasp")
+            }
+        }
+        mavenLocal()
     }
 }
 

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzerExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzerExtension.groovy
@@ -514,11 +514,11 @@ class AnalyzerExtension {
 
     /**
      * Sets whether the Node.js Analyzer should be used.
-     * @deprecated Use nodePackage { enabled = true }
+     * @deprecated since 8.4.1 - please use nodePackage.enabled = true
      */
     @Input
     @Optional
-    @Deprecated
+    @Deprecated(since = "8.4.1", forRemoval = true)
     Property<Boolean> getNodeEnabled() {
         return nodeEnabled
     }
@@ -529,11 +529,11 @@ class AnalyzerExtension {
 
     /**
      * Sets whether the NSP Analyzer should be used.
-     * @deprecated As of the 5.2.5 - please use nodeAudit { enabled = true }
+     * @deprecated since 5.2.5 - please use nodeAudit.enabled = true
      */
     @Input
     @Optional
-    @Deprecated
+    @Deprecated(since = "5.2.5", forRemoval = true)
     Property<Boolean> getNodeAuditEnabled() {
         return nodeAuditEnabled
     }
@@ -557,11 +557,11 @@ class AnalyzerExtension {
 
     /**
      * Sets whether the OSS Index Analyzer should be used.
-     * @deprecated As of the 5.0.1 - please use ossIndex { enabled = true }
+     * @deprecated since 5.0.1 - please use ossIndex.enabled = true
      */
     @Input
     @Optional
-    @Deprecated
+    @Deprecated(since = "5.0.1", forRemoval = true)
     Property<Boolean> getOssIndexEnabled() {
         return ossIndexEnabled
     }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/OssIndexExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/OssIndexExtension.groovy
@@ -34,6 +34,7 @@ class OssIndexExtension {
     private final Property<String> username
     private final Property<String> password
     private final Property<String> url
+    private final Property<Integer> validForHours
     private final Property<Boolean> warnOnlyOnRemoteErrors
 
     @Inject
@@ -42,6 +43,7 @@ class OssIndexExtension {
         this.username = objects.property(String)
         this.password = objects.property(String)
         this.url = objects.property(String)
+        this.validForHours = objects.property(Integer)
         this.warnOnlyOnRemoteErrors = objects.property(Boolean)
     }
 
@@ -95,6 +97,19 @@ class OssIndexExtension {
 
     void setUrl(String value) {
         url.set(value)
+    }
+
+    /**
+     * The number of hours to wait before checking for new updates on individual packages/components.
+     */
+    @Input
+    @Optional
+    Property<Integer> getValidForHours() {
+        return validForHours
+    }
+
+    void setValidForHours(Number value) {
+        validForHours.set(value?.intValue())
     }
 
     /**

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/ProxyExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/ProxyExtension.groovy
@@ -27,10 +27,9 @@ import org.gradle.api.tasks.Optional
 import javax.inject.Inject
 
 /**
- * TODO - this should not be needed, instead rely on the configured HTTP or HTTPS proxies
- * https://docs.gradle.org/current/userguide/build_environment.html
+ * @deprecated this should not be needed, instead rely on the configured HTTP or HTTPS proxies https://docs.gradle.org/current/userguide/build_environment.html
  */
-@Deprecated
+@Deprecated(since = "5.3.1", forRemoval = true)
 @groovy.transform.CompileStatic
 class ProxyExtension {
 
@@ -40,6 +39,7 @@ class ProxyExtension {
     private final Property<String> password
     private final ListProperty<String> nonProxyHosts
 
+    @SuppressWarnings('GrDeprecatedAPIUsage')
     @Inject
     ProxyExtension(ObjectFactory objects) {
         this.server = objects.property(String)

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
@@ -129,6 +129,7 @@ abstract class ConfiguredTask extends DefaultTask {
         settings.setStringIfNotEmpty(ANALYZER_OSSINDEX_USER, config.analyzers.ossIndex.username.getOrNull())
         settings.setStringIfNotEmpty(ANALYZER_OSSINDEX_PASSWORD, config.analyzers.ossIndex.password.getOrNull())
         settings.setStringIfNotEmpty(ANALYZER_OSSINDEX_URL, config.analyzers.ossIndex.url.getOrNull())
+        settings.setIntIfNotNull(ANALYZER_OSSINDEX_CACHE_VALID_FOR_HOURS, config.analyzers.ossIndex.validForHours.getOrNull())
 
         settings.setBooleanIfNotNull(ANALYZER_CENTRAL_ENABLED, config.analyzers.centralEnabled.getOrNull())
 

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
@@ -29,6 +29,7 @@ import spock.lang.Specification
 
 import static org.owasp.dependencycheck.utils.Settings.KEYS.*
 
+@SuppressWarnings('ConfigurationAvoidance')
 class DependencyCheckGradlePluginSpec extends Specification {
     static final String PLUGIN_ID = 'org.owasp.dependencycheck'
     Project project

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
@@ -22,6 +22,9 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.testfixtures.ProjectBuilder
 import org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension
+import org.owasp.dependencycheck.gradle.extension.NexusExtension
+import org.owasp.dependencycheck.gradle.extension.OssIndexExtension
+import org.owasp.dependencycheck.utils.Settings
 import spock.lang.Specification
 
 import static org.owasp.dependencycheck.utils.Settings.KEYS.*
@@ -221,7 +224,7 @@ class DependencyCheckGradlePluginSpec extends Specification {
     def 'NexusExtension properties configure task settings'() {
         given:
         def task = project.tasks.findByName(taskName)
-        with(project.dependencyCheck.analyzers.nexus) {
+        with(project.dependencyCheck.analyzers.nexus as NexusExtension) {
             enabled.set(true)
             usesProxy.set(true)
             url.set('https://nexus')
@@ -233,12 +236,43 @@ class DependencyCheckGradlePluginSpec extends Specification {
         task.initializeSettings()
 
         then:
-        with(task.settings) {
-            getBoolean(ANALYZER_NEXUS_ENABLED) == true
-            getBoolean(ANALYZER_NEXUS_USES_PROXY) == true
+        with(task.settings as Settings) {
+            getBoolean(ANALYZER_NEXUS_ENABLED)
+            getBoolean(ANALYZER_NEXUS_USES_PROXY)
             getString(ANALYZER_NEXUS_URL) == 'https://nexus'
             getString(ANALYZER_NEXUS_USER) == 'user'
             getString(ANALYZER_NEXUS_PASSWORD) == 'pass'
+        }
+
+        where:
+        taskName | _
+        DependencyCheckPlugin.ANALYZE_TASK | _
+        DependencyCheckPlugin.AGGREGATE_TASK | _
+    }
+
+    def 'OssIndexExtension properties configure task settings'() {
+        given:
+        def task = project.tasks.findByName(taskName)
+        with(project.dependencyCheck.analyzers.ossIndex as OssIndexExtension) {
+            enabled.set(true)
+            url.set('https://ossindex')
+            username.set('user')
+            password.set('pass')
+            validForHours.set(48)
+            warnOnlyOnRemoteErrors.set(true)
+        }
+
+        when:
+        task.initializeSettings()
+
+        then:
+        with(task.settings as Settings) {
+            getBoolean(ANALYZER_OSSINDEX_ENABLED)
+            getString(ANALYZER_OSSINDEX_URL) == 'https://ossindex'
+            getString(ANALYZER_OSSINDEX_USER) == 'user'
+            getString(ANALYZER_OSSINDEX_PASSWORD) == 'pass'
+            getInt(ANALYZER_OSSINDEX_CACHE_VALID_FOR_HOURS) == 48
+            getBoolean(ANALYZER_OSSINDEX_WARN_ONLY_ON_REMOTE_ERRORS)
         }
 
         where:

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
@@ -83,7 +83,7 @@ class DependencyCheckGradlePluginSpec extends Specification {
         project.dependencyCheck.nvd.apiKey.getOrNull() == null
         project.dependencyCheck.nvd.delay.getOrNull() == null
         project.dependencyCheck.nvd.maxRetryCount.getOrNull() == null
-        project.dependencyCheck.outputDirectory.get().asFile == project.file("${project.buildDir}/reports")
+        project.dependencyCheck.outputDirectory.get().asFile == project.layout.buildDirectory.dir('reports').get().asFile
         project.dependencyCheck.scanConfigurations.get() == []
         project.dependencyCheck.skipConfigurations.get() == []
         project.dependencyCheck.scanProjects.get() == []

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/GradleTestVersion.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/GradleTestVersion.groovy
@@ -13,7 +13,7 @@ class GradleTestVersion {
     final static def supportedVersions = [
             new GradleTestVersion(version: '7.6.6',  minJdk: 8,  maxJdk: 19),
             new GradleTestVersion(version: '8.14.4', minJdk: 8,  maxJdk: 24),
-            new GradleTestVersion(version: '9.4.1',  minJdk: 17, maxJdk: 26),
+            new GradleTestVersion(version: '9.5.0',  minJdk: 17, maxJdk: 26),
     ]
 
     final static def supportedVersionsForCurrentJvm =


### PR DESCRIPTION
Allows overriding the configuration for how long to keep OSS Index cache entries for.
- depends on https://github.com/dependency-check/DependencyCheck/pull/8451
- working and tested locally against real project.

Minor
- Adds (reinstates?) the capability to test the plugin on `master` against published ODC core snapshots
- minor bump to JUnit while fixing the dependabot config for less noise
- tidies some deprecation annotations
- bump Gradle test version